### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,11 @@ on:
         default: ''
         type: string
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
 jobs:
   samples:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
 jobs:
   format:
     name: 🎨 Format

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     name: 🔨 Generate documentation

--- a/.github/workflows/initiate_release.yml
+++ b/.github/workflows/initiate_release.yml
@@ -7,6 +7,10 @@ on:
         description: 'The new version number. Example: 1.40.1'
         required: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   init_release:
     name: Create release PR


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **8** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
