### PR TITLE
Render attachments and attach them from the composer

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -57,6 +57,10 @@ MobileProvision=build_pp.mobileprovision
 bSupportsPortraitOrientation=True
 bSupportsLandscapeLeftOrientation=False
 bSupportsLandscapeRightOrientation=False
+; PHPickerViewController runs out of process and hands back only what the user picked, so it needs
+; no photo library authorization. The description is here anyway: App Review expects it whenever the
+; binary links PhotosUI, and nothing about the picker changes if the requirement ever tightens.
+AdditionalPlistData="<key>NSPhotoLibraryUsageDescription</key><string>Choose photos to send in a chat message.</string>"
 
 [/Script/AndroidRuntimeSettings.AndroidRuntimeSettings]
 PackageName=com.Stream.[PROJECT]

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/ImageDownloadSubsystem.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/ImageDownloadSubsystem.cpp
@@ -155,13 +155,23 @@ void UImageDownloadSubsystem::DownloadImage(const FString& Url, TFunction<void(U
     const auto OnRequest =
         [WeakThis = TWeakObjectPtr<UImageDownloadSubsystem>(this), Url, Callback](FHttpRequestPtr, const FHttpResponsePtr HttpResponse, const bool bSucceeded)
     {
-        if (!bSucceeded || !HttpResponse.IsValid() || HttpResponse->GetContentLength() <= 0)
+        if (!bSucceeded || !HttpResponse.IsValid())
         {
             Callback(nullptr);
             return;
         }
 
-        UTexture2DDynamic* Texture = TryCreateTexture(HttpResponse->GetContent().GetData(), HttpResponse->GetContentLength());
+        // The received bytes, not GetContentLength(): that reports the Content-Length header, which a
+        // chunked response does not send. Stream's CDN serves images chunked, so trusting the header
+        // threw away every image it returned before it was ever decoded.
+        const TArray<uint8>& Content = HttpResponse->GetContent();
+        if (Content.Num() == 0)
+        {
+            Callback(nullptr);
+            return;
+        }
+
+        UTexture2DDynamic* Texture = TryCreateTexture(Content.GetData(), Content.Num());
         if (!Texture)
         {
             Callback(nullptr);
@@ -212,8 +222,11 @@ void UImageDownloadSubsystem::CacheToDisk(const FString& Url, const FHttpRespons
         return;
     }
 
-    void* Data = const_cast<void*>(static_cast<const void*>(Response->GetContent().GetData()));
-    FileWriter->Serialize(Data, Response->GetContentLength());
+    // Length of what actually arrived, for the same reason as above: a chunked response reports no
+    // Content-Length, and writing that many bytes would truncate the cache entry or worse
+    const TArray<uint8>& Content = Response->GetContent();
+    void* Data = const_cast<void*>(static_cast<const void*>(Content.GetData()));
+    FileWriter->Serialize(Data, Content.Num());
     FileWriter->Close();
 }
 

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/Input/AttachmentPicker.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/Input/AttachmentPicker.cpp
@@ -1,0 +1,44 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#include "Input/AttachmentPicker.h"
+
+#include "Async/Async.h"
+
+FAttachmentPicker::FProvider FAttachmentPicker::Provider;
+
+void FAttachmentPicker::SetProvider(FProvider InProvider)
+{
+    Provider = MoveTemp(InProvider);
+}
+
+void FAttachmentPicker::ClearProvider()
+{
+    Provider = nullptr;
+}
+
+bool FAttachmentPicker::HasProvider()
+{
+    return static_cast<bool>(Provider);
+}
+
+void FAttachmentPicker::Pick(FOnPicked OnPicked)
+{
+    if (!Provider || !OnPicked)
+    {
+        return;
+    }
+
+    Provider(
+        [OnPicked = MoveTemp(OnPicked)](const TOptional<FPickedAttachment>& Picked)
+        {
+            if (IsInGameThread())
+            {
+                OnPicked(Picked);
+                return;
+            }
+
+            // A platform picker reports back on whichever thread it pleases, and UIKit's main thread
+            // is not the game thread. Everything downstream of here touches UObjects.
+            AsyncTask(ENamedThreads::GameThread, [OnPicked, Copy = Picked]() { OnPicked(Copy); });
+        });
+}

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/Input/MessageComposerWidget.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/Input/MessageComposerWidget.cpp
@@ -2,10 +2,74 @@
 
 #include "Input/MessageComposerWidget.h"
 
+#include "Blueprint/WidgetTree.h"
 #include "Brushes/SlateImageBrush.h"
+#include "Components/ButtonSlot.h"
+#include "Components/HorizontalBoxSlot.h"
+#include "Components/Overlay.h"
+#include "Components/OverlaySlot.h"
+#include "Components/SizeBox.h"
 #include "Context/ChannelContextWidget.h"
 #include "ThemeDataAsset.h"
 #include "TimerManager.h"
+
+namespace
+{
+/**
+ * The nearest ancestor of Widget that can hold more than one child.
+ *
+ * WBP_MessageComposer wraps the send button in a size box, and a size box holds exactly one child:
+ * inserting into it would evict the button rather than sit beside it.
+ */
+UPanelWidget* FindPanelWithRoomForMore(const UWidget* Widget)
+{
+    UPanelWidget* Panel = Widget ? Cast<UPanelWidget>(Widget->GetParent()) : nullptr;
+    while (Panel && !Panel->CanHaveMultipleChildren())
+    {
+        Panel = Cast<UPanelWidget>(Panel->GetParent());
+    }
+    return Panel;
+}
+}    // namespace
+
+UWidget* UMessageComposerWidget::BuildAttachIcon()
+{
+    UImage* Icon = WidgetTree->ConstructWidget<UImage>();
+    Icon->SetBrushFromTexture(IconTextureAttach, true);
+    return Icon;
+}
+
+UWidget* UMessageComposerWidget::BuildAttachGlyph()
+{
+    // Two crossed bars rather than a "+" in a text block. A glyph sits on its font's baseline, with
+    // room reserved below it for descenders, so centring the text block leaves the plus visibly high;
+    // these are centred by construction. The plugin ships no paperclip texture to use instead.
+    UOverlay* Glyph = WidgetTree->ConstructWidget<UOverlay>();
+
+    const float Length = AttachButtonSize.X * AttachGlyphScale;
+    const float Thickness = FMath::Max(1.f, FMath::RoundToFloat(AttachButtonSize.X * AttachGlyphThickness));
+
+    for (const FVector2D& BarSize : {FVector2D{Length, Thickness}, FVector2D{Thickness, Length}})
+    {
+        // A bar is an image with no texture, which slate draws as a solid rectangle in the tint
+        // colour, the same way the dividers elsewhere in this plugin are drawn. Its size comes from
+        // the brush, since UImage::SetBrushSize is deprecated and SetDesiredSizeOverride is not
+        // reapplied when the slate widget is rebuilt.
+        UImage* Bar = WidgetTree->ConstructWidget<UImage>();
+        FSlateBrush BarBrush = Bar->GetBrush();
+        BarBrush.ImageSize = BarSize;
+        Bar->SetBrush(BarBrush);
+        AttachGlyphBars.Add(Bar);
+
+        if (UOverlaySlot* BarSlot = Cast<UOverlaySlot>(Glyph->AddChild(Bar)))
+        {
+            BarSlot->SetHorizontalAlignment(HAlign_Center);
+            BarSlot->SetVerticalAlignment(VAlign_Center);
+        }
+    }
+
+    return Glyph;
+}
 
 void UMessageComposerWidget::NativeOnInitialized()
 {
@@ -23,7 +87,74 @@ void UMessageComposerWidget::NativeOnInitialized()
         SendMessageButton->OnClicked.AddDynamic(this, &UMessageComposerWidget::OnSendButtonClicked);
     }
 
+    CreateAttachmentWidgets();
+
     Super::NativeOnInitialized();
+}
+
+void UMessageComposerWidget::CreateAttachmentWidgets()
+{
+    // No picker means the app has no way of choosing a file, so offering the button would be a lie
+    if (!FAttachmentPicker::HasProvider() || !WidgetTree || !SendMessageButton)
+    {
+        return;
+    }
+
+    UPanelWidget* InputRow = FindPanelWithRoomForMore(SendMessageButton);
+    if (!InputRow)
+    {
+        return;
+    }
+
+    AttachButton = WidgetTree->ConstructWidget<UButton>();
+    AttachButton->OnClicked.AddDynamic(this, &UMessageComposerWidget::OnAttachButtonClicked);
+
+    // Flat, and with the style's own padding removed: the engine's default button background would
+    // look nothing like the rest of the composer, and its padding would push the icon off centre.
+    FButtonStyle Style = AttachButton->GetStyle();
+    for (FSlateBrush* Brush : {&Style.Normal, &Style.Hovered, &Style.Pressed, &Style.Disabled})
+    {
+        Brush->DrawAs = ESlateBrushDrawType::NoDrawType;
+    }
+    Style.NormalPadding = FMargin{0.f};
+    Style.PressedPadding = FMargin{0.f};
+    AttachButton->SetStyle(Style);
+
+    AttachButtonIcon = IconTextureAttach ? BuildAttachIcon() : BuildAttachGlyph();
+    if (UButtonSlot* ButtonSlot = Cast<UButtonSlot>(AttachButton->SetContent(AttachButtonIcon)))
+    {
+        ButtonSlot->SetPadding(FMargin{0.f});
+        ButtonSlot->SetHorizontalAlignment(HAlign_Center);
+        ButtonSlot->SetVerticalAlignment(VAlign_Center);
+    }
+
+    USizeBox* Sizer = WidgetTree->ConstructWidget<USizeBox>();
+    Sizer->SetWidthOverride(AttachButtonSize.X);
+    Sizer->SetHeightOverride(AttachButtonSize.Y);
+    Sizer->AddChild(AttachButton);
+
+    if (UHorizontalBoxSlot* BoxSlot = Cast<UHorizontalBoxSlot>(InputRow->InsertChildAt(0, Sizer)))
+    {
+        BoxSlot->SetVerticalAlignment(VAlign_Center);
+    }
+
+    // The status line goes below the "Edit Message" header, if this composer has one
+    if (CancelEditingHeaderPanel)
+    {
+        if (UPanelWidget* Column = FindPanelWithRoomForMore(CancelEditingHeaderPanel))
+        {
+            AttachStatusTextBlock = WidgetTree->ConstructWidget<UTextBlock>();
+            AttachStatusTextBlock->SetVisibility(ESlateVisibility::Collapsed);
+            FSlateFontInfo Font = AttachStatusTextBlock->GetFont();
+            Font.Size = 12;
+            AttachStatusTextBlock->SetFont(Font);
+
+            // Directly below the header when they share a parent, otherwise at the top of whatever
+            // column we did find, which is still above the input
+            const int32 HeaderIndex = Column->GetChildIndex(CancelEditingHeaderPanel);
+            Column->InsertChildAt(HeaderIndex == INDEX_NONE ? 0 : HeaderIndex + 1, AttachStatusTextBlock);
+        }
+    }
 }
 
 void UMessageComposerWidget::NativeConstruct()
@@ -53,6 +184,22 @@ void UMessageComposerWidget::NativeConstruct()
         {
             TopBorderImage->SetColorAndOpacity(Theme->GetPaletteColor(Theme->MessageComposerBorderColor));
         }
+        if (AttachButtonIcon)
+        {
+            const FLinearColor& Color = Theme->GetPaletteColor(Theme->MessageComposerAttachIconColor);
+            if (UImage* AsIcon = Cast<UImage>(AttachButtonIcon))
+            {
+                AsIcon->SetColorAndOpacity(Color);
+            }
+            for (UImage* Bar : AttachGlyphBars)
+            {
+                Bar->SetColorAndOpacity(Color);
+            }
+        }
+        if (AttachStatusTextBlock)
+        {
+            AttachStatusTextBlock->SetColorAndOpacity(Theme->GetPaletteColor(Theme->MessageComposerAttachStatusTextColor));
+        }
     }
 
     UpdateSendButtonAppearance(false);
@@ -80,10 +227,10 @@ void UMessageComposerWidget::EditMessage(const FMessage& Message)
     UpdateEditMessageAppearance(ESendButtonIconAppearance::Confirm);
 }
 
-void UMessageComposerWidget::OnInputTextChanged(const FText& Text)
+void UMessageComposerWidget::OnInputTextChanged(const FText&)
 {
     Keystroke();
-    UpdateSendButtonAppearance(!Text.IsEmpty());
+    RefreshSendButtonEnabled();
 }
 
 void UMessageComposerWidget::OnInputTextCommit(const FText&, const ETextCommit::Type CommitMethod)
@@ -111,6 +258,111 @@ void UMessageComposerWidget::OnSendButtonClicked()
     StopTyping();
 }
 
+void UMessageComposerWidget::OnAttachButtonClicked()
+{
+    if (bUploading)
+    {
+        return;
+    }
+
+    FAttachmentPicker::Pick(
+        [WeakThis = TWeakObjectPtr<UMessageComposerWidget>(this)](const TOptional<FPickedAttachment>& Picked)
+        {
+            if (WeakThis.IsValid() && Picked.IsSet())
+            {
+                WeakThis->Upload(*Picked);
+            }
+        });
+}
+
+void UMessageComposerWidget::Upload(const FPickedAttachment& Picked)
+{
+    UChatChannel* Channel = UChannelContextWidget::TryGetChannel(this);
+    if (!Channel || Picked.Content.IsEmpty())
+    {
+        return;
+    }
+
+    bUploading = true;
+    UpdateAttachmentAppearance();
+    SetStatus(FString::Printf(TEXT("Uploading %s..."), *Picked.FileName));
+
+    const auto OnUploaded = [WeakThis = TWeakObjectPtr<UMessageComposerWidget>(this), FileName = Picked.FileName](const FAttachment& Attachment)
+    {
+        if (!WeakThis.IsValid())
+        {
+            return;
+        }
+
+        WeakThis->bUploading = false;
+
+        // The upload endpoint answers with a URL and nothing else, so an empty one is the failure
+        if (Attachment.GetUrl().IsEmpty())
+        {
+            WeakThis->UpdateAttachmentAppearance();
+            WeakThis->SetStatus(FString::Printf(TEXT("Could not upload %s"), *FileName));
+            return;
+        }
+
+        WeakThis->PendingAttachments.Add(Attachment);
+        WeakThis->UpdateAttachmentAppearance();
+    };
+
+    if (Picked.bIsImage)
+    {
+        Channel->UploadImage(Picked.FileName, Picked.Content, OnUploaded);
+    }
+    else
+    {
+        Channel->UploadFile(Picked.FileName, Picked.Content, OnUploaded);
+    }
+}
+
+void UMessageComposerWidget::SetStatus(const FString& Status)
+{
+    if (!AttachStatusTextBlock)
+    {
+        return;
+    }
+
+    AttachStatusTextBlock->SetText(FText::FromString(Status));
+    AttachStatusTextBlock->SetVisibility(Status.IsEmpty() ? ESlateVisibility::Collapsed : ESlateVisibility::SelfHitTestInvisible);
+}
+
+void UMessageComposerWidget::UpdateAttachmentAppearance()
+{
+    if (AttachButton)
+    {
+        AttachButton->SetIsEnabled(!bUploading);
+    }
+    RefreshSendButtonEnabled();
+
+    if (bUploading)
+    {
+        // Whoever started the upload names the file being uploaded
+        return;
+    }
+
+    if (PendingAttachments.IsEmpty())
+    {
+        SetStatus({});
+    }
+    else if (PendingAttachments.Num() == 1)
+    {
+        SetStatus(FString::Printf(TEXT("%s attached"), *PendingAttachments[0].Title));
+    }
+    else
+    {
+        SetStatus(FString::Printf(TEXT("%d files attached"), PendingAttachments.Num()));
+    }
+}
+
+void UMessageComposerWidget::RefreshSendButtonEnabled()
+{
+    const bool bHasText = MessageInput && !MessageInput->GetText().IsEmpty();
+    UpdateSendButtonAppearance(bHasText || !PendingAttachments.IsEmpty());
+}
+
 void UMessageComposerWidget::SendMessage()
 {
     if (!MessageInput)
@@ -119,12 +371,13 @@ void UMessageComposerWidget::SendMessage()
     }
 
     const FString Text = MessageInput->GetText().ToString();
-    if (Text.IsEmpty())
+    // A message with an attachment and no caption is perfectly valid
+    if (Text.IsEmpty() && PendingAttachments.IsEmpty())
     {
         return;
     }
 
-    if (Text[0] == TEXT('/'))
+    if (!Text.IsEmpty() && Text[0] == TEXT('/'))
     {
         UE_LOG(LogTemp, Warning, TEXT("The Unreal SDK doesn't currently support slash commands"));
         return;
@@ -146,14 +399,22 @@ void UMessageComposerWidget::SendMessage()
     }
     else
     {
-        Channel->SendMessage(FMessage{Text});
+        FMessage Message{Text};
+        Message.Attachments = MoveTemp(PendingAttachments);
+        PendingAttachments.Reset();
+
+        Channel->SendMessage(Message);
         MessageInput->SetText(FText::GetEmpty());
+        UpdateAttachmentAppearance();
     }
 }
 
 void UMessageComposerWidget::UpdateSendButtonAppearance(const bool bEnabled)
 {
-    SendMessageButton->SetEnabled(bEnabled);
+    if (SendMessageButton)
+    {
+        SendMessageButton->SetEnabled(bEnabled);
+    }
 }
 
 void UMessageComposerWidget::StopEditMessage()

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/Message/AttachmentLayout.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/Message/AttachmentLayout.cpp
@@ -1,0 +1,43 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#include "AttachmentLayout.h"
+
+namespace AttachmentLayout
+{
+FVector2D FitToBudget(const FIntPoint Source, const float BudgetWidth, const float MaxAspect, const float DpiScale)
+{
+    if (Source.X <= 0 || Source.Y <= 0)
+    {
+        // Nothing to take an aspect ratio from, so reserve a modest landscape box for now
+        return FVector2D{BudgetWidth, FMath::RoundToFloat(BudgetWidth * 0.6f)};
+    }
+
+    const float Scale = FMath::Max(1.f, DpiScale);
+    const float NaturalWidth = static_cast<float>(Source.X) / Scale;
+
+    float Width = FMath::Min(BudgetWidth, NaturalWidth);
+    float Height = Width * static_cast<float>(Source.Y) / static_cast<float>(Source.X);
+
+    // Too tall: shrink the whole thing until the height fits, rather than squashing the picture
+    const float MaxHeight = Width * FMath::Max(1.f, MaxAspect);
+    if (Height > MaxHeight)
+    {
+        Width *= MaxHeight / Height;
+        Height = MaxHeight;
+    }
+
+    return FVector2D{FMath::RoundToFloat(Width), FMath::RoundToFloat(Height)};
+}
+
+FString WithResizeQuery(const FString& Url, const FIntPoint MaxPixels)
+{
+    if (!Url.Contains(TEXT("stream-io-cdn.com/"), ESearchCase::IgnoreCase) || MaxPixels.X <= 0 || MaxPixels.Y <= 0)
+    {
+        return Url;
+    }
+
+    const TCHAR* Separator = Url.Contains(TEXT("?")) ? TEXT("&") : TEXT("?");
+    return FString::Printf(TEXT("%s%sw=%d&h=%d&resize=clip"), *Url, Separator, MaxPixels.X, MaxPixels.Y);
+}
+
+}    // namespace AttachmentLayout

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/Message/AttachmentLayout.h
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/Message/AttachmentLayout.h
@@ -1,0 +1,36 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/// Working out how much room an inline image gets, kept apart from the widget so it can be tested
+namespace AttachmentLayout
+{
+/**
+ * @brief The size, in slate units, to draw an image of the given pixel dimensions at.
+ *
+ * Fitted to BudgetWidth with the height following from the aspect ratio, which is never distorted.
+ * An image smaller than the budget is left at its own size rather than blown up, and one taller than
+ * MaxAspect times its width is scaled down as a whole so a single photo cannot fill the message list.
+ *
+ * @param Source Pixel dimensions of the image, or anything non-positive if they are not known yet
+ * @param BudgetWidth Widest the image may be drawn, in slate units
+ * @param MaxAspect How many times its own width the image may be tall
+ * @param DpiScale Slate units per pixel, so a source's own size can be compared against the budget
+ */
+FVector2D FitToBudget(FIntPoint Source, float BudgetWidth, float MaxAspect, float DpiScale);
+
+/**
+ * @brief Ask Stream's CDN for an image no bigger than it is about to be drawn.
+ *
+ * A photo straight off a phone camera runs to 25 megapixels, which is 93 MB once decoded to BGRA,
+ * for something that ends up a couple of hundred points wide. `resize=clip` fits the image inside
+ * the box without distorting it, and never enlarges.
+ *
+ * Only Stream's CDN understands these, so any other URL is returned untouched rather than being sent
+ * query parameters it might reject.
+ */
+FString WithResizeQuery(const FString& Url, FIntPoint MaxPixels);
+
+}    // namespace AttachmentLayout

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/Message/AttachmentWidget.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/Message/AttachmentWidget.cpp
@@ -1,0 +1,291 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#include "Message/AttachmentWidget.h"
+
+#include "AttachmentLayout.h"
+#include "Blueprint/WidgetLayoutLibrary.h"
+#include "Blueprint/WidgetTree.h"
+#include "Components/VerticalBox.h"
+#include "Components/VerticalBoxSlot.h"
+#include "Engine/Engine.h"
+#include "Engine/Texture2DDynamic.h"
+#include "ImageDownloadSubsystem.h"
+#include "ThemeDataAsset.h"
+
+namespace
+{
+/// Last path segment of a URL, without the query string
+FString FileNameFromUrl(const FString& Url)
+{
+    FString Path;
+    if (!Url.Split(TEXT("?"), &Path, nullptr))
+    {
+        Path = Url;
+    }
+
+    FString FileName;
+    if (Path.Split(TEXT("/"), nullptr, &FileName, ESearchCase::IgnoreCase, ESearchDir::FromEnd))
+    {
+        return FileName;
+    }
+    return Path;
+}
+
+void SetFontSize(UTextBlock& TextBlock, const int32 Size)
+{
+    FSlateFontInfo Font = TextBlock.GetFont();
+    Font.Size = Size;
+    TextBlock.SetFont(Font);
+}
+}    // namespace
+
+void UAttachmentWidget::Setup(const FAttachment& InAttachment, const EMessageSide InSide)
+{
+    Attachment = InAttachment;
+    Side = InSide;
+
+    Super::Setup();
+}
+
+void UAttachmentWidget::OnSetup()
+{
+    UPanelWidget* Panel = GetOrCreateContentPanel();
+    if (!Panel || !WidgetTree)
+    {
+        return;
+    }
+
+    // Setup can run more than once: UStreamWidget::Initialize calls it with whatever the widget was
+    // constructed with, before the caller has had the chance to hand over an attachment.
+    Panel->ClearChildren();
+    bImageLoaded = false;
+
+    const bool bInline = ShouldRenderInline();
+
+    Image = WidgetTree->ConstructWidget<UImage>();
+    ImageSizer = WidgetTree->ConstructWidget<USizeBox>();
+    ImageSizer->AddChild(Image);
+    ImageSizer->SetVisibility(bInline ? ESlateVisibility::SelfHitTestInvisible : ESlateVisibility::Collapsed);
+    Panel->AddChild(ImageSizer);
+
+    // The backend reports the original dimensions, so the right amount of room can be reserved before
+    // the image arrives and the message list does not jump when it does
+    const TOptional<int32> SourceWidth = Attachment.ExtraData.GetNumber<int32>(TEXT("original_width"));
+    const TOptional<int32> SourceHeight = Attachment.ExtraData.GetNumber<int32>(TEXT("original_height"));
+    ApplyImageSize(GetImageDisplaySize(SourceWidth.Get(0), SourceHeight.Get(0)));
+
+    FileRow = WidgetTree->ConstructWidget<UBorder>();
+    FileRow->SetPadding(FileRowPadding);
+    FileRow->SetVisibility(bInline ? ESlateVisibility::Collapsed : ESlateVisibility::SelfHitTestInvisible);
+    Panel->AddChild(FileRow);
+
+    UVerticalBox* Lines = WidgetTree->ConstructWidget<UVerticalBox>();
+    FileRow->SetContent(Lines);
+
+    TitleTextBlock = WidgetTree->ConstructWidget<UTextBlock>();
+    TitleTextBlock->SetText(FText::FromString(GetTitle()));
+    TitleTextBlock->SetAutoWrapText(true);
+    // A hard wrap width rather than a size box: auto wrapping inside one measures the unwrapped text
+    // for the desired height and then clips whatever the wrap pushes onto a second line.
+    TitleTextBlock->SetWrapTextAt(GetImageBudgetWidth());
+    Lines->AddChild(TitleTextBlock);
+
+    const FString Subtitle = GetSubtitle();
+    SubtitleTextBlock = WidgetTree->ConstructWidget<UTextBlock>();
+    SubtitleTextBlock->SetText(FText::FromString(Subtitle));
+    SubtitleTextBlock->SetVisibility(Subtitle.IsEmpty() ? ESlateVisibility::Collapsed : ESlateVisibility::SelfHitTestInvisible);
+    Lines->AddChild(SubtitleTextBlock);
+
+    if (bInline)
+    {
+        FetchRemoteImage();
+    }
+}
+
+void UAttachmentWidget::NativePreConstruct()
+{
+    Super::NativePreConstruct();
+
+    const UThemeDataAsset* Theme = GetTheme();
+    if (!Theme)
+    {
+        return;
+    }
+
+    if (Image && !bImageLoaded)
+    {
+        // Tint the empty brush so a downloading image reads as a placeholder rather than a gap
+        Image->SetColorAndOpacity(Theme->GetPaletteColor(Theme->AttachmentImagePlaceholderColor));
+    }
+
+    if (FileRow)
+    {
+        const FName Color = Side == EMessageSide::Me ? Theme->MeAttachmentRowColor : Theme->YouAttachmentRowColor;
+        FileRow->SetBrushColor(Theme->GetPaletteColor(Color));
+    }
+
+    if (TitleTextBlock)
+    {
+        TitleTextBlock->SetColorAndOpacity(Theme->GetPaletteColor(Theme->AttachmentTitleTextColor));
+        SetFontSize(*TitleTextBlock, TitleFontSize);
+    }
+
+    if (SubtitleTextBlock)
+    {
+        SubtitleTextBlock->SetColorAndOpacity(Theme->GetPaletteColor(Theme->AttachmentSubtitleTextColor));
+        SetFontSize(*SubtitleTextBlock, SubtitleFontSize);
+    }
+}
+
+bool UAttachmentWidget::ShouldRenderInline() const
+{
+    const bool bIsPicture = Attachment.Type == EAttachmentType::Image || Attachment.Type == EAttachmentType::Giphy;
+    return bIsPicture && !Attachment.GetUrl().IsEmpty();
+}
+
+void UAttachmentWidget::FetchRemoteImage()
+{
+    UImageDownloadSubsystem* Subsystem = GEngine ? GEngine->GetEngineSubsystem<UImageDownloadSubsystem>() : nullptr;
+    if (!Subsystem)
+    {
+        return;
+    }
+
+    FString Url = Attachment.GetUrl();
+    if (bRequestResizedImages)
+    {
+        // Slate units times the DPI factor gives pixels, and the box is allowed to be taller than it
+        // is wide so a portrait photo still comes back fitted to its width
+        const int32 WidthPixels = FMath::CeilToInt(GetImageBudgetWidth() * GetDpiScale());
+        Url = AttachmentLayout::WithResizeQuery(Url, FIntPoint{WidthPixels, FMath::CeilToInt(WidthPixels * MaxImageAspect)});
+    }
+
+    Subsystem->DownloadImage(
+        Url,
+        [WeakThis = TWeakObjectPtr<UAttachmentWidget>(this)](UTexture2DDynamic* Texture)
+        {
+            if (WeakThis.IsValid())
+            {
+                WeakThis->OnImageDownloaded(Texture);
+            }
+        });
+}
+
+void UAttachmentWidget::OnImageDownloaded(UTexture2DDynamic* Texture)
+{
+    if (!Image || !FileRow || !ImageSizer)
+    {
+        return;
+    }
+
+    if (!Texture)
+    {
+        // Nothing to draw, so fall back to naming the file like any other attachment
+        ImageSizer->SetVisibility(ESlateVisibility::Collapsed);
+        FileRow->SetVisibility(ESlateVisibility::SelfHitTestInvisible);
+        return;
+    }
+
+    bImageLoaded = true;
+    // bMatchSize would set the brush to the source's pixel dimensions, which is not what it gets
+    // drawn at; the size box decides that, and the brush is told to agree
+    Image->SetBrushFromTextureDynamic(Texture, false);
+    Image->SetColorAndOpacity(FLinearColor::White);
+    ApplyImageSize(GetImageDisplaySize(Texture->SizeX, Texture->SizeY));
+    Invalidate(EInvalidateWidgetReason::LayoutAndVolatility);
+}
+
+float UAttachmentWidget::GetAvailableWidth() const
+{
+    // No world means no viewport to measure, which is the case in an offline test
+    if (!GetWorld())
+    {
+        return MaxImageWidth;
+    }
+
+    const float Scale = UWidgetLayoutLibrary::GetViewportScale(this);
+    const FVector2D Viewport = UWidgetLayoutLibrary::GetViewportSize(this);
+    if (Scale <= 0.f || Viewport.X <= 1.f)
+    {
+        return MaxImageWidth;
+    }
+
+    // Slate units, so the fraction means the same thing on a handset and on a desktop
+    return static_cast<float>(Viewport.X) / Scale;
+}
+
+float UAttachmentWidget::GetImageBudgetWidth() const
+{
+    return FMath::Min(GetAvailableWidth() * ImageWidthFraction, MaxImageWidth);
+}
+
+FVector2D UAttachmentWidget::GetImageDisplaySize(const int32 SourceWidth, const int32 SourceHeight) const
+{
+    return AttachmentLayout::FitToBudget(FIntPoint{SourceWidth, SourceHeight}, GetImageBudgetWidth(), MaxImageAspect, GetDpiScale());
+}
+
+float UAttachmentWidget::GetDpiScale() const
+{
+    return GetWorld() ? FMath::Max(1.f, UWidgetLayoutLibrary::GetViewportScale(this)) : 1.f;
+}
+
+void UAttachmentWidget::ApplyImageSize(const FVector2D& Size)
+{
+    if (!ImageSizer)
+    {
+        return;
+    }
+
+    // The size box alone decides the geometry. The brush's own size only feeds the desired size,
+    // which the overrides above replace, so there is nothing to keep in step with it.
+    ImageSizer->SetWidthOverride(static_cast<float>(Size.X));
+    ImageSizer->SetHeightOverride(static_cast<float>(Size.Y));
+}
+
+FString UAttachmentWidget::GetTitle() const
+{
+    if (!Attachment.Title.IsEmpty())
+    {
+        return Attachment.Title;
+    }
+    if (!Attachment.Text.IsEmpty())
+    {
+        return Attachment.Text;
+    }
+
+    const FString FileName = FileNameFromUrl(Attachment.GetUrl());
+    return FileName.IsEmpty() ? TEXT("Attachment") : FileName;
+}
+
+FString UAttachmentWidget::GetSubtitle() const
+{
+    TArray<FString> Parts;
+    if (!Attachment.MimeType.IsEmpty())
+    {
+        Parts.Add(Attachment.MimeType);
+    }
+    if (Attachment.FileSize > 0)
+    {
+        Parts.Add(FText::AsMemory(Attachment.FileSize).ToString());
+    }
+    return FString::Join(Parts, TEXT(" · "));
+}
+
+UPanelWidget* UAttachmentWidget::GetOrCreateContentPanel()
+{
+    if (ContentPanel)
+    {
+        return ContentPanel;
+    }
+
+    if (!WidgetTree)
+    {
+        return nullptr;
+    }
+
+    // No widget blueprint bound a panel, so this widget is the whole tree
+    UVerticalBox* Generated = WidgetTree->ConstructWidget<UVerticalBox>();
+    WidgetTree->RootWidget = Generated;
+    ContentPanel = Generated;
+    return ContentPanel;
+}

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/Message/MessageWidget.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/Message/MessageWidget.cpp
@@ -136,6 +136,8 @@ void UMessageWidget::OnSetup()
         }
     }
 
+    CreateAttachmentWidgets();
+
     // Align everything in the outer panel to the left or right
     if (AlignPanel)
     {
@@ -195,4 +197,39 @@ void UMessageWidget::NativeOnMouseLeave(const FPointerEvent& InMouseEvent)
 bool UMessageWidget::ShouldDisplayHoverMenu() const
 {
     return HoverMenuTargetPanel && Message.Type != EMessageType::Deleted;
+}
+
+void UMessageWidget::CreateAttachmentWidgets()
+{
+    if (!AlignPanel)
+    {
+        return;
+    }
+
+    for (UAttachmentWidget* Previous : Attachments)
+    {
+        AlignPanel->RemoveChild(Previous);
+    }
+    Attachments.Reset();
+
+    if (Message.Type == EMessageType::Deleted)
+    {
+        return;
+    }
+
+    // WBP_Message has no slot for these, so they go straight into the panel that handles the
+    // left/right alignment, ahead of the bubble. The loop below then aligns them like everything
+    // else in there.
+    int32 Index = 0;
+    for (const FAttachment& Attachment : Message.Attachments)
+    {
+        UAttachmentWidget* Widget = CreateWidget<UAttachmentWidget>(this, AttachmentWidgetClass);
+        Widget->Setup(Attachment, Side);
+
+        if (UVerticalBoxSlot* BoxSlot = Cast<UVerticalBoxSlot>(AlignPanel->InsertChildAt(Index++, Widget)))
+        {
+            BoxSlot->SetPadding(AttachmentPadding);
+        }
+        Attachments.Add(Widget);
+    }
 }

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/Tests/AttachmentWidgetTest.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/Tests/AttachmentWidgetTest.cpp
@@ -1,0 +1,224 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#include "Blueprint/WidgetTree.h"
+#include "Components/Border.h"
+#include "Components/Image.h"
+#include "Components/SizeBox.h"
+#include "Components/TextBlock.h"
+#include "CoreTypes.h"
+#include "Message/AttachmentLayout.h"
+#include "Message/AttachmentWidget.h"
+#include "Misc/AutomationTest.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+namespace
+{
+/**
+ * Build the widget the way the message list does, minus the viewport.
+ *
+ * CreateWidget wants a world, which an offline test has no business standing up, so the two steps it
+ * would do are done by hand. Initialize() is public on UUserWidget and private in UStreamWidget, so
+ * it is called through a base pointer.
+ */
+UAttachmentWidget* MakeAttachmentWidget(const FAttachment& Attachment)
+{
+    // Defaulted outer rather than GetTransientPackage(): it is the same transient package, without
+    // needing UPackage to be a complete type in a translation unit that has no other use for it.
+    UAttachmentWidget* Widget = NewObject<UAttachmentWidget>();
+    static_cast<UUserWidget*>(Widget)->Initialize();
+    Widget->Setup(Attachment, EMessageSide::You);
+    return Widget;
+}
+
+template <class T>
+T* FindFirst(const UAttachmentWidget& Widget)
+{
+    T* Found = nullptr;
+    Widget.WidgetTree->ForEachWidget(
+        [&Found](UWidget* Child)
+        {
+            if (!Found)
+            {
+                Found = Cast<T>(Child);
+            }
+        });
+    return Found;
+}
+
+/// Every text block in the widget, in tree order: the filename first, then the type and size
+TArray<UTextBlock*> FindTextBlocks(const UAttachmentWidget& Widget)
+{
+    TArray<UTextBlock*> Found;
+    Widget.WidgetTree->ForEachWidget(
+        [&Found](UWidget* Child)
+        {
+            if (UTextBlock* AsText = Cast<UTextBlock>(Child))
+            {
+                Found.Add(AsText);
+            }
+        });
+    return Found;
+}
+
+bool IsShown(const UWidget* Widget)
+{
+    return Widget && Widget->GetVisibility() != ESlateVisibility::Collapsed && Widget->GetVisibility() != ESlateVisibility::Hidden;
+}
+}    // namespace
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FAttachmentWidgetTest,
+    "StreamChat.Ui.AttachmentWidget",
+    EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FAttachmentWidgetTest::RunTest(const FString& Parameters)
+{
+    // An image is drawn inline, and the row naming the file stays out of the way
+    {
+        FAttachment Attachment;
+        Attachment.Type = EAttachmentType::Image;
+        Attachment.ImageUrl = TEXT("https://example.com/shot.png");
+        Attachment.Title = TEXT("shot.png");
+
+        const UAttachmentWidget* Widget = MakeAttachmentWidget(Attachment);
+        TestTrue("Image is shown", IsShown(FindFirst<USizeBox>(*Widget)));
+        TestFalse("File row is hidden", IsShown(FindFirst<UBorder>(*Widget)));
+    }
+
+    // Anything we cannot draw gets the row instead
+    {
+        FAttachment Attachment;
+        Attachment.Type = EAttachmentType::File;
+        Attachment.AssetUrl = TEXT("https://example.com/report.pdf");
+        Attachment.Title = TEXT("report.pdf");
+        Attachment.MimeType = TEXT("application/pdf");
+        Attachment.FileSize = 2048;
+
+        const UAttachmentWidget* Widget = MakeAttachmentWidget(Attachment);
+        TestFalse("Image is hidden", IsShown(FindFirst<USizeBox>(*Widget)));
+        TestTrue("File row is shown", IsShown(FindFirst<UBorder>(*Widget)));
+
+        const TArray<UTextBlock*> Texts = FindTextBlocks(*Widget);
+        if (TestEqual("Title and subtitle", Texts.Num(), 2))
+        {
+            TestEqual("Title is the filename", Texts[0]->GetText().ToString(), TEXT("report.pdf"));
+            TestTrue("Subtitle names the type", Texts[1]->GetText().ToString().Contains(TEXT("application/pdf")));
+            TestTrue("Subtitle is shown", IsShown(Texts[1]));
+        }
+    }
+
+    // An image type with no URL cannot be drawn, so it must not leave an empty box behind
+    {
+        FAttachment Attachment;
+        Attachment.Type = EAttachmentType::Image;
+
+        const UAttachmentWidget* Widget = MakeAttachmentWidget(Attachment);
+        TestFalse("Image is hidden", IsShown(FindFirst<USizeBox>(*Widget)));
+        TestTrue("File row is shown", IsShown(FindFirst<UBorder>(*Widget)));
+    }
+
+    // A scraped link arrives with no title at all, so the filename comes from the URL, and the query
+    // string CDNs sign their URLs with must not end up in it
+    {
+        FAttachment Attachment;
+        Attachment.Type = EAttachmentType::File;
+        Attachment.AssetUrl = TEXT("https://cdn.example.com/1146612/files/report.pdf?Key-Pair-Id=ABC&Signature=xyz");
+
+        const UAttachmentWidget* Widget = MakeAttachmentWidget(Attachment);
+        const TArray<UTextBlock*> Texts = FindTextBlocks(*Widget);
+        if (TestEqual("Title and subtitle", Texts.Num(), 2))
+        {
+            TestEqual("Title from URL", Texts[0]->GetText().ToString(), TEXT("report.pdf"));
+            TestFalse("No subtitle to show", IsShown(Texts[1]));
+        }
+    }
+
+    // Setting the widget up twice must replace the previous contents rather than stack onto them,
+    // because UStreamWidget::Initialize already ran Setup once with an empty attachment
+    {
+        FAttachment Attachment;
+        Attachment.Type = EAttachmentType::File;
+        Attachment.Title = TEXT("first.txt");
+
+        UAttachmentWidget* Widget = MakeAttachmentWidget(Attachment);
+
+        FAttachment Replacement;
+        Replacement.Type = EAttachmentType::File;
+        Replacement.Title = TEXT("second.txt");
+        Widget->Setup(Replacement, EMessageSide::Me);
+
+        const TArray<UTextBlock*> Texts = FindTextBlocks(*Widget);
+        if (TestEqual("No leftovers from the first setup", Texts.Num(), 2))
+        {
+            TestEqual("Shows the second attachment", Texts[0]->GetText().ToString(), TEXT("second.txt"));
+        }
+    }
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FAttachmentLayoutTest,
+    "StreamChat.Ui.AttachmentLayout",
+    EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FAttachmentLayoutTest::RunTest(const FString& Parameters)
+{
+    constexpr float Budget = 260.f;
+    constexpr float MaxAspect = 2.f;
+
+    // A photo off a phone camera. It must come out at the budget width, not its own 4284 pixels:
+    // drawn at source size it covered the entire message list.
+    {
+        const FVector2D Size = AttachmentLayout::FitToBudget(FIntPoint{4284, 5712}, Budget, MaxAspect, 2.f);
+        TestEqual("Fitted to the budget width", Size.X, 260.0);
+        TestEqual("Height follows the aspect ratio", Size.Y, 347.0);
+    }
+
+    // Aspect ratio is never distorted to make something fit
+    {
+        const FVector2D Size = AttachmentLayout::FitToBudget(FIntPoint{1000, 250}, Budget, MaxAspect, 1.f);
+        TestEqual("Fitted to the budget width", Size.X, 260.0);
+        TestEqual("Stays 4:1", Size.Y, 65.0);
+    }
+
+    // Something smaller than the budget is left alone rather than blown up into a blurry mess
+    {
+        const FVector2D Size = AttachmentLayout::FitToBudget(FIntPoint{120, 80}, Budget, MaxAspect, 1.f);
+        TestEqual("Kept at its own width", Size.X, 120.0);
+        TestEqual("Kept at its own height", Size.Y, 80.0);
+    }
+
+    // A very tall image shrinks as a whole, so it cannot run off the bottom of the list
+    {
+        const FVector2D Size = AttachmentLayout::FitToBudget(FIntPoint{1000, 10000}, Budget, MaxAspect, 1.f);
+        TestEqual("Height capped at the budget times the aspect limit", Size.Y, 520.0);
+        TestEqual("Width shrunk to match, not squashed", Size.X, 52.0);
+    }
+
+    // Nothing to measure yet, before the backend has told us anything about the image
+    {
+        const FVector2D Size = AttachmentLayout::FitToBudget(FIntPoint{0, 0}, Budget, MaxAspect, 1.f);
+        TestEqual("Reserves the budget width", Size.X, 260.0);
+        TestTrue("Reserves some height", Size.Y > 0.0);
+    }
+
+    // Stream's CDN resizes on request, which is what keeps a 25 megapixel photo from being decoded
+    // in full on a handset. The signed URL already has a query string, so this has to append to it.
+    {
+        const FString Signed = TEXT("https://dublin.stream-io-cdn.com/1146612/images/a.jpg?Key-Pair-Id=ABC&Signature=xyz");
+        const FString Resized = AttachmentLayout::WithResizeQuery(Signed, FIntPoint{512, 1024});
+        TestTrue("Appends to the existing query", Resized.StartsWith(Signed + TEXT("&")));
+        TestTrue("Fits within the box without distorting", Resized.EndsWith(TEXT("w=512&h=1024&resize=clip")));
+    }
+
+    // Any other host is left alone: the parameters are Stream's, and a stranger may reject them
+    {
+        const FString Foreign = TEXT("https://upload.wikimedia.org/wikipedia/commons/a.jpg");
+        TestEqual("Untouched", AttachmentLayout::WithResizeQuery(Foreign, FIntPoint{512, 1024}), Foreign);
+    }
+
+    return true;
+}
+#endif

--- a/Plugins/StreamChat/Source/StreamChatUi/Public/Input/AttachmentPicker.h
+++ b/Plugins/StreamChat/Source/StreamChatUi/Public/Input/AttachmentPicker.h
@@ -1,0 +1,61 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * @brief A file the app picked, ready to be uploaded and attached to a message.
+ * @ingroup StreamChatUi
+ */
+struct FPickedAttachment
+{
+    /// Original filename, shown to recipients and used by the backend to infer the MIME type
+    FString FileName;
+
+    /// Raw bytes of the file
+    TArray<uint8> Content;
+
+    /// Upload through the image endpoint, so recipients get a thumbnail and render it inline
+    bool bIsImage = false;
+};
+
+/**
+ * @brief Supplies the message composer with a way to pick a file to attach.
+ *
+ * The SDK ships no picker of its own. Picking a file is a platform decision -- a photo library on a
+ * handset, a file dialog on desktop, a baked-in asset in a game -- and the plugin stays portable by
+ * not making it. Register a provider and the composer grows an attach button; register nothing and
+ * it does not.
+ *
+ * @code
+ * FAttachmentPicker::SetProvider([](FAttachmentPicker::FOnPicked OnPicked) {
+ *     // Show your picker, then, whenever the user is done:
+ *     FPickedAttachment Picked{TEXT("shot.png"), MoveTemp(Bytes), true};
+ *     OnPicked(Picked);   // or OnPicked({}) if they cancelled
+ * });
+ * @endcode
+ *
+ * @ingroup StreamChatUi
+ */
+class STREAMCHATUI_API FAttachmentPicker
+{
+public:
+    /// Called by a provider once the user has chosen a file, or with nothing if they cancelled.
+    /// Always delivered on the game thread, whichever thread the provider calls it from.
+    using FOnPicked = TFunction<void(const TOptional<FPickedAttachment>&)>;
+
+    /// Shows a picker and reports back what the user chose
+    using FProvider = TFunction<void(FOnPicked)>;
+
+    /// Register the app's picker. Replaces any previously registered one.
+    static void SetProvider(FProvider);
+    static void ClearProvider();
+    static bool HasProvider();
+
+    /// Ask the registered provider for a file. Does nothing if none is registered.
+    static void Pick(FOnPicked);
+
+private:
+    static FProvider Provider;
+};

--- a/Plugins/StreamChat/Source/StreamChatUi/Public/Input/MessageComposerWidget.h
+++ b/Plugins/StreamChat/Source/StreamChatUi/Public/Input/MessageComposerWidget.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "AttachmentPicker.h"
 #include "Blueprint/UserWidget.h"
 #include "Channel/ChatChannel.h"
 #include "Common/IconButton.h"
@@ -70,6 +71,26 @@ protected:
     UPROPERTY(EditAnywhere, Category = "Icon")
     FMargin IconPaddingConfirm;
 
+    /**
+     * @brief Icon for the attach button.
+     *
+     * The plugin ships no paperclip of its own, so when this is unset the button draws a plus built
+     * out of two bars instead. Assign a texture here to get a proper icon.
+     */
+    UPROPERTY(EditAnywhere, Category = "Icon")
+    UTexture2D* IconTextureAttach;
+
+    UPROPERTY(EditAnywhere, Category = "Attachment")
+    FVector2D AttachButtonSize = FVector2D{32.f, 32.f};
+
+    /// Length of each bar of the drawn plus, as a fraction of the button
+    UPROPERTY(EditAnywhere, Category = "Attachment", meta = (ClampMin = "0.1", ClampMax = "1.0"))
+    float AttachGlyphScale = 0.5f;
+
+    /// Thickness of each bar of the drawn plus, as a fraction of the button
+    UPROPERTY(EditAnywhere, Category = "Attachment", meta = (ClampMin = "0.01", ClampMax = "0.5"))
+    float AttachGlyphThickness = 0.06f;
+
 private:
     UFUNCTION()
     void OnInputTextChanged(const FText& Text);
@@ -79,13 +100,25 @@ private:
     void OnCancelEditingButtonClicked();
     UFUNCTION()
     void OnSendButtonClicked();
+    UFUNCTION()
+    void OnAttachButtonClicked();
 
     void SendMessage();
     void StopEditMessage();
     void Keystroke();
     void StopTyping();
 
+    /// Build the attach button and its status line, if the app registered a picker to feed them
+    void CreateAttachmentWidgets();
+    UWidget* BuildAttachIcon();
+    UWidget* BuildAttachGlyph();
+    void Upload(const FPickedAttachment& Picked);
+    void SetStatus(const FString& Status);
+    void UpdateAttachmentAppearance();
+
     void UpdateSendButtonAppearance(bool bEnabled);
+    /// A message may carry text, attachments, or both, so the send button follows all of it
+    void RefreshSendButtonEnabled();
 
     enum class ESendButtonIconAppearance
     {
@@ -95,4 +128,23 @@ private:
     void UpdateEditMessageAppearance(ESendButtonIconAppearance Appearance);
 
     TOptional<FMessage> EditedMessage;
+
+    /// Uploaded and waiting to go out with the next message
+    UPROPERTY(Transient)
+    TArray<FAttachment> PendingAttachments;
+
+    // Spawned in C++: WBP_MessageComposer predates attachments and has no slot to bind them to
+    UPROPERTY(Transient)
+    UButton* AttachButton;
+    /// Whatever the attach button draws: the icon texture, or the plus built out of bars
+    UPROPERTY(Transient)
+    UWidget* AttachButtonIcon;
+    /// The bars of the drawn plus, kept so the theme can colour them
+    UPROPERTY(Transient)
+    TArray<UImage*> AttachGlyphBars;
+    UPROPERTY(Transient)
+    UTextBlock* AttachStatusTextBlock;
+
+    /// One upload at a time, so the status line always describes the upload in flight
+    bool bUploading = false;
 };

--- a/Plugins/StreamChat/Source/StreamChatUi/Public/Message/AttachmentWidget.h
+++ b/Plugins/StreamChat/Source/StreamChatUi/Public/Message/AttachmentWidget.h
@@ -1,0 +1,130 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "Channel/Attachment.h"
+#include "Components/Border.h"
+#include "Components/Image.h"
+#include "Components/PanelWidget.h"
+#include "Components/SizeBox.h"
+#include "Components/TextBlock.h"
+#include "CoreMinimal.h"
+#include "MessageSide.h"
+#include "StreamWidget.h"
+
+#include "AttachmentWidget.generated.h"
+
+class UTexture2DDynamic;
+
+/**
+ * @brief Displays a single attachment of a message.
+ *
+ * Images are downloaded and shown inline. Everything else gets a row naming the file, because the
+ * SDK has no way of opening arbitrary content that would work on every platform it supports.
+ *
+ * Unlike the other widgets here this one builds its own UMG tree in C++, so it needs no widget
+ * blueprint. Point UMessageWidget::AttachmentWidgetClass at your own class to replace it, or give a
+ * subclass a widget blueprint with a panel named ContentPanel and the content will be built into
+ * that instead of into a generated root.
+ * @ingroup StreamChatUi
+ */
+UCLASS()
+class STREAMCHATUI_API UAttachmentWidget : public UStreamWidget
+{
+    GENERATED_BODY()
+
+public:
+    UFUNCTION(BlueprintCallable, Category = "Stream Chat")
+    void Setup(const FAttachment& InAttachment, EMessageSide InSide);
+
+protected:
+    /// Holds the attachment content. Generated in C++ when no widget blueprint provides one.
+    UPROPERTY(meta = (BindWidgetOptional))
+    UPanelWidget* ContentPanel;
+
+    /// How much of the width an inline image may take. Its height then follows from its aspect ratio.
+    UPROPERTY(EditDefaultsOnly, Category = Defaults, meta = (ClampMin = "0.1", ClampMax = "1.0"))
+    float ImageWidthFraction = 0.66f;
+
+    /// Ceiling on the above, so an image does not run away with a wide desktop window
+    UPROPERTY(EditDefaultsOnly, Category = Defaults)
+    float MaxImageWidth = 320.f;
+
+    /// How many times its own width an image may be tall before it is fitted by height instead
+    UPROPERTY(EditDefaultsOnly, Category = Defaults, meta = (ClampMin = "1.0"))
+    float MaxImageAspect = 2.f;
+
+    /**
+     * @brief Ask Stream's CDN for an image scaled to roughly the size it will be drawn at.
+     *
+     * A photo off a phone camera is around 25 megapixels, which is 93 MB once decoded, for something
+     * that ends up a couple of hundred points wide. Turn this off to always fetch the original.
+     */
+    UPROPERTY(EditDefaultsOnly, Category = Defaults)
+    bool bRequestResizedImages = true;
+
+    UPROPERTY(EditDefaultsOnly, Category = Defaults)
+    FMargin FileRowPadding = FMargin{12.f, 8.f};
+
+    // Only the size is configurable: the typeface is taken from whatever font the text block already
+    // carries, which keeps this working without a font asset of our own.
+    UPROPERTY(EditDefaultsOnly, Category = Defaults)
+    int32 TitleFontSize = 14;
+
+    UPROPERTY(EditDefaultsOnly, Category = Defaults)
+    int32 SubtitleFontSize = 12;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Setup)
+    FAttachment Attachment;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Setup)
+    EMessageSide Side = EMessageSide::You;
+
+private:
+    virtual void OnSetup() override;
+    virtual void NativePreConstruct() override;
+
+    /// True when the attachment is something we can fetch and draw ourselves
+    bool ShouldRenderInline() const;
+    void FetchRemoteImage();
+    void OnImageDownloaded(UTexture2DDynamic* Texture);
+
+    /// Width available to lay out in, in slate units. Falls back to the ceiling with no viewport.
+    float GetAvailableWidth() const;
+    /// Widest an image is allowed to be drawn
+    float GetImageBudgetWidth() const;
+    /**
+     * The size to draw a source of the given pixel dimensions at.
+     *
+     * Fitted to the budget width with the height following the aspect ratio, and never enlarged past
+     * the source's own size, so a small image is not blown up into a blurry one.
+     */
+    FVector2D GetImageDisplaySize(int32 SourceWidth, int32 SourceHeight) const;
+    /// Slate units per pixel. 1 with no viewport to ask.
+    float GetDpiScale() const;
+    void ApplyImageSize(const FVector2D& Size);
+
+    /// Filename or, failing that, something better than an empty row
+    FString GetTitle() const;
+    /// Type and size of the file, when the backend told us either
+    FString GetSubtitle() const;
+
+    UPanelWidget* GetOrCreateContentPanel();
+
+    // Both the image and the file row are built for every attachment: an image that fails to
+    // download falls back to the row, and there is no theme to style a late-built one with.
+    UPROPERTY(Transient)
+    UImage* Image;
+    // The image is sized by this rather than by UImage::SetDesiredSizeOverride, which does nothing
+    // unless the slate widget already exists and is not reapplied when it is rebuilt
+    UPROPERTY(Transient)
+    USizeBox* ImageSizer;
+    UPROPERTY(Transient)
+    UBorder* FileRow;
+    UPROPERTY(Transient)
+    UTextBlock* TitleTextBlock;
+    UPROPERTY(Transient)
+    UTextBlock* SubtitleTextBlock;
+
+    bool bImageLoaded = false;
+};

--- a/Plugins/StreamChat/Source/StreamChatUi/Public/Message/MessageWidget.h
+++ b/Plugins/StreamChat/Source/StreamChatUi/Public/Message/MessageWidget.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "AttachmentWidget.h"
 #include "Channel/Message.h"
 #include "Components/Overlay.h"
 #include "CoreMinimal.h"
@@ -62,8 +63,15 @@ protected:
     UPROPERTY(EditDefaultsOnly, NoClear, Category = Defaults)
     TSubclassOf<UTimestampWidget> TimestampWidgetClass = UTimestampWidget::StaticClass();
 
+    UPROPERTY(EditDefaultsOnly, NoClear, Category = Defaults)
+    TSubclassOf<UAttachmentWidget> AttachmentWidgetClass = UAttachmentWidget::StaticClass();
+
     UPROPERTY(EditDefaultsOnly, Category = Defaults)
     int32 AvatarSize = 36;
+
+    /// Space around each attachment shown above the message
+    UPROPERTY(EditDefaultsOnly, Category = Defaults)
+    FMargin AttachmentPadding = FMargin{0.f, 0.f, 0.f, 2.f};
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Setup)
     FMessage Message;
@@ -80,6 +88,8 @@ private:
 
     bool ShouldDisplayHoverMenu() const;
 
+    void CreateAttachmentWidgets();
+
     // Only valid while hovered
     UPROPERTY(Transient)
     UMessageHoverMenuWidget* MouseHoverMenu;
@@ -87,4 +97,8 @@ private:
     // Only valid if message has reactions
     UPROPERTY(Transient)
     UMessageReactionsWidget* Reactions;
+
+    // Live in AlignPanel rather than a panel of their own, so tracked here to be replaced on re-setup
+    UPROPERTY(Transient)
+    TArray<UAttachmentWidget*> Attachments;
 };

--- a/Plugins/StreamChat/Source/StreamChatUi/Public/ThemeDataAsset.h
+++ b/Plugins/StreamChat/Source/StreamChatUi/Public/ThemeDataAsset.h
@@ -50,6 +50,22 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Styles|Message Bubble")
     FHtmlElementStyles BubbleHtmlStyles;
 
+    /// The background color of a non-image attachment attached to a message sent by the current user
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Attachment")
+    FName MeAttachmentRowColor = TEXT("borders");
+    /// The background color of a non-image attachment attached to a message sent by another user
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Attachment")
+    FName YouAttachmentRowColor = TEXT("bars-bg");
+    /// The color of the filename of a non-image attachment
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Attachment")
+    FName AttachmentTitleTextColor = TEXT("text-high-emphasis");
+    /// The color of the type and size of a non-image attachment
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Attachment")
+    FName AttachmentSubtitleTextColor = TEXT("text-low-emphasis");
+    /// The color of the space an inline image occupies while it is still downloading
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Attachment")
+    FName AttachmentImagePlaceholderColor = TEXT("input-bg");
+
     /// The color of the background of the message composer
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Message Composer")
     FName MessageComposerBackgroundColor = TEXT("bars-bg");
@@ -59,6 +75,12 @@ public:
     /// The color of the header text (e.g. "Edit Message" or "Reply to Message")
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Message Composer")
     FName MessageComposerHeaderTextColor = TEXT("text-high-emphasis");
+    /// The color of the icon on the button which attaches a file to a message
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Message Composer")
+    FName MessageComposerAttachIconColor = TEXT("text-low-emphasis");
+    /// The color of the line reporting what is attached to the message being composed
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Message Composer")
+    FName MessageComposerAttachStatusTextColor = TEXT("text-low-emphasis");
 
     /// The color of the input text
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Message Input")

--- a/Source/StreamChatSample/IOSAttachmentPicker.mm
+++ b/Source/StreamChatSample/IOSAttachmentPicker.mm
@@ -1,0 +1,147 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#include "SampleAttachmentPicker.h"
+
+// Compiled on every Apple platform but only meant for the handset. The matching no-op lives in
+// SampleAttachmentPicker.cpp, which takes over wherever this is empty or not compiled at all.
+#if PLATFORM_IOS
+
+#include "IOS/IOSAppDelegate.h"
+#include "Input/AttachmentPicker.h"
+
+#import <PhotosUI/PhotosUI.h>
+#import <UIKit/UIKit.h>
+
+namespace
+{
+constexpr CGFloat JpegQuality = 0.9;
+
+FString ToFString(NSString* String)
+{
+    return String ? FString{UTF8_TO_TCHAR([String UTF8String])} : FString{};
+}
+}    // namespace
+
+/**
+ * Keeps the SDK's callback alive while the system picker is on screen, and turns whatever the user
+ * chose into the filename and bytes the SDK asked for.
+ *
+ * PHPickerViewController holds its delegate weakly, so this object owns itself between being handed
+ * to the picker and reporting back. UE builds Objective-C++ without ARC, hence the explicit release.
+ */
+@interface FStreamSamplePhotoPicker : NSObject <PHPickerViewControllerDelegate>
+- (instancetype)initWithCallback:(FAttachmentPicker::FOnPicked)Callback;
+@end
+
+@implementation FStreamSamplePhotoPicker
+{
+    FAttachmentPicker::FOnPicked OnPicked;
+}
+
+- (instancetype)initWithCallback:(FAttachmentPicker::FOnPicked)Callback
+{
+    self = [super init];
+    if (self)
+    {
+        OnPicked = MoveTemp(Callback);
+    }
+    return self;
+}
+
+/// Hand the result back exactly once, then give up the reference that kept us alive
+- (void)report:(const TOptional<FPickedAttachment>&)Picked
+{
+    if (OnPicked)
+    {
+        OnPicked(Picked);
+        OnPicked.Reset();
+    }
+    [self release];
+}
+
+- (void)picker:(PHPickerViewController*)Picker didFinishPicking:(NSArray<PHPickerResult*>*)Results
+{
+    [Picker dismissViewControllerAnimated:YES completion:nil];
+
+    PHPickerResult* Result = Results.firstObject;
+    if (!Result || ![Result.itemProvider canLoadObjectOfClass:[UIImage class]])
+    {
+        // Cancelled, or gave us something we cannot read
+        [self report:TOptional<FPickedAttachment>{}];
+        return;
+    }
+
+    NSString* SuggestedName = Result.itemProvider.suggestedName;
+    [Result.itemProvider
+        loadObjectOfClass:[UIImage class]
+        completionHandler:^(__kindof id<NSItemProviderReading> Object, NSError* Error)
+        {
+            UIImage* Photo = [Object isKindOfClass:[UIImage class]] ? (UIImage*)Object : nil;
+
+            // Re-encode as JPEG rather than uploading what the library holds. An iPhone stores HEIC,
+            // Stream serves back what it was given, and the SDK's image cache only decodes PNG, JPEG
+            // and BMP -- so a HEIC photo would upload cleanly and then fail to draw in the message.
+            NSData* Jpeg = Photo ? UIImageJPEGRepresentation(Photo, JpegQuality) : nil;
+            if (!Jpeg || Jpeg.length == 0)
+            {
+                [self report:TOptional<FPickedAttachment>{}];
+                return;
+            }
+
+            const FString BaseName = ToFString(SuggestedName);
+
+            FPickedAttachment Picked;
+            Picked.FileName = (BaseName.IsEmpty() ? FString{TEXT("photo")} : BaseName) + TEXT(".jpg");
+            Picked.bIsImage = true;
+            Picked.Content.Append(static_cast<const uint8*>(Jpeg.bytes), static_cast<int32>(Jpeg.length));
+
+            [self report:TOptional<FPickedAttachment>{MoveTemp(Picked)}];
+        }];
+}
+
+@end
+
+namespace
+{
+void PresentPhotoPicker(FAttachmentPicker::FOnPicked OnPicked)
+{
+    dispatch_async(
+        dispatch_get_main_queue(),
+        ^{
+            // IOSAppDelegate.h only forward declares IOSViewController, so the compiler cannot see
+            // that it descends from UIViewController. It always does -- directly on tvOS/visionOS
+            // and via GCEventViewController everywhere else -- so the cast is safe, and it saves
+            // pulling IOSView.h and the GameController framework in behind it.
+            UIViewController* Presenter = (UIViewController*)[IOSAppDelegate GetDelegate].IOSController;
+            if (!Presenter)
+            {
+                OnPicked({});
+                return;
+            }
+
+            PHPickerConfiguration* Configuration = [[[PHPickerConfiguration alloc] init] autorelease];
+            Configuration.selectionLimit = 1;
+            Configuration.filter = [PHPickerFilter imagesFilter];
+
+            PHPickerViewController* Picker = [[[PHPickerViewController alloc] initWithConfiguration:Configuration] autorelease];
+
+            // The +1 from alloc is deliberate: the picker's delegate reference is weak, so this is
+            // what keeps the delegate alive until it reports back and releases itself.
+            Picker.delegate = [[FStreamSamplePhotoPicker alloc] initWithCallback:OnPicked];
+
+            [Presenter presentViewController:Picker animated:YES completion:nil];
+        });
+}
+}    // namespace
+
+void RegisterSampleAttachmentPicker()
+{
+    FAttachmentPicker::SetProvider([](FAttachmentPicker::FOnPicked OnPicked) { PresentPhotoPicker(MoveTemp(OnPicked)); });
+}
+
+void UnregisterSampleAttachmentPicker()
+{
+    FAttachmentPicker::ClearProvider();
+}
+
+#endif    // PLATFORM_IOS

--- a/Source/StreamChatSample/SampleAttachmentPicker.cpp
+++ b/Source/StreamChatSample/SampleAttachmentPicker.cpp
@@ -1,0 +1,18 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#include "SampleAttachmentPicker.h"
+
+// The iOS picker is Objective-C and lives in IOSAttachmentPicker.mm, which only Apple platforms
+// compile. This provides the same two symbols everywhere else, so the game module links whatever it
+// is built for.
+#if !PLATFORM_IOS
+
+void RegisterSampleAttachmentPicker()
+{
+}
+
+void UnregisterSampleAttachmentPicker()
+{
+}
+
+#endif    // !PLATFORM_IOS

--- a/Source/StreamChatSample/SampleAttachmentPicker.h
+++ b/Source/StreamChatSample/SampleAttachmentPicker.h
@@ -1,0 +1,18 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * @brief Registers this sample's file picker with the chat UI.
+ *
+ * The plugin has no picker of its own on purpose: it takes bytes, never a path, so that none of the
+ * platform differences in choosing a file leak into it. This is the app's half of that bargain, and
+ * it is where the one piece of Objective-C in the project lives.
+ *
+ * On iOS this puts up a PHPickerViewController. Everywhere else it registers nothing, and the
+ * composer quietly leaves out its attach button.
+ */
+void RegisterSampleAttachmentPicker();
+void UnregisterSampleAttachmentPicker();

--- a/Source/StreamChatSample/StreamChatSample.Build.cs
+++ b/Source/StreamChatSample/StreamChatSample.Build.cs
@@ -10,6 +10,14 @@ public class StreamChatSample : ModuleRules
 
 		PublicDependencyModuleNames.AddRange(new[] { "Core", "CoreUObject", "Engine", "InputCore" });
 
-		PrivateDependencyModuleNames.AddRange(new[] { "StreamChat" });
+		// StreamChatUi is here only for FAttachmentPicker, which the sample fills in with the photo
+		// picker below. The plugin itself never touches a platform framework.
+		PrivateDependencyModuleNames.AddRange(new[] { "StreamChat", "StreamChatUi" });
+
+		if (Target.Platform == UnrealTargetPlatform.IOS)
+		{
+			PrivateDependencyModuleNames.Add("ApplicationCore");
+			PublicFrameworks.AddRange(new[] { "Photos", "PhotosUI" });
+		}
 	}
 }

--- a/Source/StreamChatSample/StreamChatSample.cpp
+++ b/Source/StreamChatSample/StreamChatSample.cpp
@@ -3,5 +3,25 @@
 #include "StreamChatSample.h"
 
 #include "Modules/ModuleManager.h"
+#include "SampleAttachmentPicker.h"
 
-IMPLEMENT_PRIMARY_GAME_MODULE(FDefaultGameModuleImpl, StreamChatSample, "StreamChatSample");
+/**
+ * The sample hands the chat UI a file picker as the module starts, well before any widget is built,
+ * because the composer decides whether to offer an attach button by asking whether one exists.
+ */
+class FStreamChatSampleModule final : public FDefaultGameModuleImpl
+{
+    virtual void StartupModule() override
+    {
+        FDefaultGameModuleImpl::StartupModule();
+        RegisterSampleAttachmentPicker();
+    }
+
+    virtual void ShutdownModule() override
+    {
+        UnregisterSampleAttachmentPicker();
+        FDefaultGameModuleImpl::ShutdownModule();
+    }
+};
+
+IMPLEMENT_PRIMARY_GAME_MODULE(FStreamChatSampleModule, StreamChatSample, "StreamChatSample");


### PR DESCRIPTION
#153 added the backend half of attachments — uploads, DTOs and `UChatChannel::UploadFile`/`UploadImage`. Until now an upload succeeded and the message list still showed text only. This adds the display and input halves, and fixes two pre-existing bugs found on the way.

## Rendering

`UAttachmentWidget` draws a single attachment: images inline via `UImageDownloadSubsystem`, anything else as a row naming the file (the SDK has no way to open arbitrary content that works on every platform). It builds its own UMG tree in C++, so it needs no widget blueprint — `UMessageWidget` spawns one per attachment and inserts it into the already-bound `AlignPanel`, ahead of the bubble, where the existing left/right alignment picks it up. **No `.uasset` changes.**

Point `UMessageWidget::AttachmentWidgetClass` at your own class to replace it, or give a subclass a widget blueprint with a panel named `ContentPanel`.

## Composer

An attach button appears when — and only when — the app has registered an `FAttachmentPicker` provider. The SDK ships no picker of its own: choosing a file is a platform decision, and the plugin stays portable by not making it. Uploads ride out with the next message, and a message carrying an attachment and no text now sends.

The plugin ships no paperclip texture, so the button draws a plus built from two bars. Assign `IconTextureAttach` on the composer to use a real icon instead.

## Sample only

`IOSAttachmentPicker.mm` puts up a `PHPickerViewController` behind `#if PLATFORM_IOS` and registers itself as the provider at module startup. It re-encodes the photo as JPEG: iPhones store HEIC, Stream serves back what it was given, and the image cache only decodes PNG/JPEG/BMP — so a HEIC photo would upload cleanly and then fail to draw.

**No platform code, `PLATFORM_` branch or filesystem access enters the plugin**, so Windows and Linux are unaffected.

## Two pre-existing bugs fixed

Both are in `UImageDownloadSubsystem` and also affect avatars:

- It discarded every response whose `Content-Length` **header** was missing. Stream's CDN serves images `Transfer-Encoding: chunked`, so **no image it returned was ever decoded**. Now uses the bytes actually received.
- `CacheToDisk` wrote `Content-Length` bytes rather than the received length, which would truncate or over-read a cache entry.

## Image sizing

A photo off a phone camera is ~25 MP — **93 MB** decoded to BGRA, for something a couple of hundred points wide — so the CDN is asked to resize (`resize=clip`, aspect preserved, never enlarging). For one test photo that is 26 KB instead of 2 MB. Only Stream CDN URLs get the parameters; any other host is left untouched.

The sizing itself lives in `AttachmentLayout`, kept apart from the widget so it can be tested: fitted to two thirds of the available width with the height following the aspect ratio, never enlarged past the source, and scaled down as a whole when an image is too tall. The backend's `original_width`/`original_height` reserve the right space before the download so the list does not jump.

## Testing

Strict builds (`-NoPCH -NoSharedPCH -DisableUnity`) clean and **47/47 automation tests on both UE 5.7 and 5.8**, with `Intermediate/Build` cleaned between engines. Two new offline specs cover the widget's branch logic and the sizing maths.

Verified on a physical iPhone: app starts clean, the picker uploads (HTTP 201), and the resized image decodes and renders.

### Note for reviewers

`Config/DefaultEngine.ini` gains only an `NSPhotoLibraryUsageDescription` plist entry. `PHPickerViewController` runs out of process and needs no photo library authorization, but App Review expects the key whenever the binary links PhotosUI.

If you package this for a device, use `-cook`, not `-skipcook` — this changes `UPROPERTY` layouts, and cooked Blueprint CDOs are serialized unversioned, so a stale cook aborts on map load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)