### PR TITLE
Release: 2.1.0

### DIFF
--- a/Plugins/StreamChat/StreamChat.uplugin
+++ b/Plugins/StreamChat/StreamChat.uplugin
@@ -1,7 +1,7 @@
 {
     "FileVersion": 3,
-    "Version": 27,
-    "VersionName": "2.0.0",
+    "Version": 28,
+    "VersionName": "2.1.0",
     "EngineVersion": "5.8.0",
     "FriendlyName": "Stream Chat",
     "Description": "Official Unreal Plugin for Stream Chat",

--- a/Plugins/StreamChat/StreamChat.uplugin.5.7
+++ b/Plugins/StreamChat/StreamChat.uplugin.5.7
@@ -1,7 +1,7 @@
 {
     "FileVersion": 3,
-    "Version": 27,
-    "VersionName": "2.0.0",
+    "Version": 28,
+    "VersionName": "2.1.0",
     "EngineVersion": "5.7.0",
     "FriendlyName": "Stream Chat",
     "Description": "Official Unreal Plugin for Stream Chat",

--- a/Plugins/StreamChat/StreamChat.uplugin.5.8
+++ b/Plugins/StreamChat/StreamChat.uplugin.5.8
@@ -1,7 +1,7 @@
 {
     "FileVersion": 3,
-    "Version": 27,
-    "VersionName": "2.0.0",
+    "Version": 28,
+    "VersionName": "2.1.0",
     "EngineVersion": "5.8.0",
     "FriendlyName": "Stream Chat",
     "Description": "Official Unreal Plugin for Stream Chat",


### PR DESCRIPTION
# :rocket: 2.1.0

Make sure to use squash & merge when merging!
Once this is merged, another job will kick off automatically and publish the package.

Bumps `Version` 27 to 28 and `VersionName` 2.0.0 to 2.1.0 across the three `.uplugin` files (`StreamChat.uplugin`, `.5.7`, `.5.8`).

## What's in it

- **Threads and replies** (#157). The write path, `GetReplies` / `QueryThreads` / `GetThread`, per-thread reply storage, `FChatThread` and the thread list surface, plus long press on a message in the sample to open the reaction picker and the message actions. A minor bump rather than a patch, since this adds API.
- Earlier on `main` since 2.0.0: the iOS attachment picker moved into a platform folder (#156), attachment rendering and composer attachments (#154), file and image attachments (#153).

Docs for the feature: [docs-content#1495](https://github.com/GetStream/docs-content/pull/1495).

## Verification of the released tree

Both engines, strict non-unity builds (`-NoPCH -NoSharedPCH -DisableUnity`), full automation suite:

| | build | tests |
| --- | --- | --- |
| UE 5.7 | Succeeded, 0 errors, 0 warnings | 59/59 |
| UE 5.8.1 | Succeeded, 0 errors, 0 warnings | 59/59 |

Each engine was wiped and rebuilt rather than reusing the other's output, confirmed by the `BuildId` in `UnrealEditor.modules` changing (5.7 `47537391`, 5.8 `55116800`).

One run hit the known `StreamChat.ChatApi.Channel` flake (`Expected 'Channel muted' to be true`, an eventual-consistency assertion in that block's shared `LatentBeforeEach`, unrelated to anything in this release). Two clean 59/59 runs followed.

## Note for the release process

`initiate_release.yml` could not do this itself: its `permissions:` block grants `contents: read`, so pushing the release branch fails with `Permission to GetStream/stream-chat-unreal.git denied to github-actions[bot]` (403). The bump and commit succeed, only the push is denied. See run [31398622527](https://github.com/GetStream/stream-chat-unreal/actions/runs/31398622527). This branch was therefore prepared with the same steps run locally. Worth fixing the workflow to `contents: write` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)