### PR TITLE
Moderation V2 and bounced messages

### DIFF
--- a/Plugins/StreamChat/Source/Backend/StreamChatApi/Private/ChatApi.cpp
+++ b/Plugins/StreamChat/Source/Backend/StreamChatApi/Private/ChatApi.cpp
@@ -162,9 +162,23 @@ void FChatApi::QueryBannedUsers(
     Client->Get(Url).Query({{TEXT("payload"), Payload}}).Send(Callback);
 }
 
-void FChatApi::Flag(const FString& TargetMessageId, const FString& TargetUserId, const TCallback<FFlagResponseDto> Callback) const
+void FChatApi::Flag(
+    const FString& TargetMessageId,
+    const FString& TargetUserId,
+    const FString& Reason,
+    const TMap<FString, FString>& CustomData,
+    const TCallback<FFlagResponseDto> Callback) const
 {
     const FString Url = BuildUrl(TEXT("moderation/flag"));
+    const FFlagRequestDto Body{TargetMessageId, TargetUserId, Reason, CustomData};
+    Client->Post(Url).Json(Body).Send(Callback);
+}
+
+void FChatApi::Unflag(const FString& TargetMessageId, const FString& TargetUserId, const TCallback<FFlagResponseDto> Callback) const
+{
+    const FString Url = BuildUrl(TEXT("moderation/unflag"));
+    // Same body as flagging, minus the reason and custom data: they described the flag being raised,
+    // and the endpoint takes only the target of the one being withdrawn.
     const FFlagRequestDto Body{TargetMessageId, TargetUserId};
     Client->Post(Url).Json(Body).Send(Callback);
 }

--- a/Plugins/StreamChat/Source/Backend/StreamChatApi/Public/ChatApi.h
+++ b/Plugins/StreamChat/Source/Backend/StreamChatApi/Public/ChatApi.h
@@ -132,12 +132,27 @@ public:
         TCallback<FQueryBannedUsersResponseDto> Callback = {}) const;
 
     /**
-     * @brief Flag a user or message
+     * @brief Flag a user or message for a moderator to review
      * @param TargetMessageId ID of message to flag (optional)
      * @param TargetUserId ID of user to flag (optional)
+     * @param Reason Why the content was reported. Shown to moderators in the review queue. (optional)
+     * @param CustomData Extra key/value pairs to attach to the flag (optional)
      * @param Callback Called when response is received.
      */
-    void Flag(const FString& TargetMessageId = {}, const FString& TargetUserId = {}, TCallback<FFlagResponseDto> Callback = {}) const;
+    void Flag(
+        const FString& TargetMessageId = {},
+        const FString& TargetUserId = {},
+        const FString& Reason = {},
+        const TMap<FString, FString>& CustomData = {},
+        TCallback<FFlagResponseDto> Callback = {}) const;
+
+    /**
+     * @brief Withdraw a flag this user previously raised against a user or message
+     * @param TargetMessageId ID of message to unflag (optional)
+     * @param TargetUserId ID of user to unflag (optional)
+     * @param Callback Called when response is received.
+     */
+    void Unflag(const FString& TargetMessageId = {}, const FString& TargetUserId = {}, TCallback<FFlagResponseDto> Callback = {}) const;
 
     /**
      * @brief Mute a user

--- a/Plugins/StreamChat/Source/Backend/StreamChatApiTest/Private/Tests/ChatApi.spec.cpp
+++ b/Plugins/StreamChat/Source/Backend/StreamChatApiTest/Private/Tests/ChatApi.spec.cpp
@@ -784,10 +784,26 @@ void FChatApiSpec::Define()
                     Api->Flag(
                         MessageId,
                         {},
+                        TEXT("spam"),
+                        {{TEXT("source"), TEXT("automated test")}},
                         [=, this](const TResponse<FFlagResponseDto>& Response)
                         {
                             const auto& Dto = Response.GetRef();
                             TestEqual("Message ID matches query", Dto.Flag.TargetMessageId, MessageId);
+                            TestDone.Execute();
+                        });
+                });
+
+            LatentIt(
+                "Unflag message",
+                [=, this](const FDoneDelegate& TestDone)
+                {
+                    Api->Unflag(
+                        MessageId,
+                        {},
+                        [=, this](const TResponse<FFlagResponseDto>& Response)
+                        {
+                            TestTrue("Flag withdrawn", Response.IsSuccessful());
                             TestDone.Execute();
                         });
                 });

--- a/Plugins/StreamChat/Source/Backend/StreamChatDto/Public/Request/Moderation/FlagRequestDto.h
+++ b/Plugins/StreamChat/Source/Backend/StreamChatDto/Public/Request/Moderation/FlagRequestDto.h
@@ -23,4 +23,12 @@ struct STREAMCHATDTO_API FFlagRequestDto
     /// ID of the user when reporting a user
     UPROPERTY()
     FString TargetUserId;
+
+    /// Why the content was reported. Shown to moderators in the review queue.
+    UPROPERTY()
+    FString Reason;
+
+    /// Extra key/value pairs to attach to the flag, surfaced alongside it in the review queue
+    UPROPERTY()
+    TMap<FString, FString> Custom;
 };

--- a/Plugins/StreamChat/Source/Backend/StreamChatDto/Public/Response/Message/MessageDto.h
+++ b/Plugins/StreamChat/Source/Backend/StreamChatDto/Public/Response/Message/MessageDto.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "MessageTypeDto.h"
 #include "Response/Message/AttachmentDto.h"
+#include "Response/Moderation/MessageModerationDto.h"
 #include "Response/Reaction/ReactionDto.h"
 #include "UserObjectDto.h"
 
@@ -71,6 +72,16 @@ struct STREAMCHATDTO_API FMessageDto
     /// Should be empty if `text` is provided
     UPROPERTY()
     FString Mml;
+
+    /// The moderation verdict for this message, as sent by Moderation V2
+    UPROPERTY()
+    FMessageModerationDto Moderation;
+
+    /// The moderation verdict for this message, as sent by the older moderation API
+    ///
+    /// Apps still on that version get their verdict here instead of in Moderation, so both are read.
+    UPROPERTY()
+    FMessageModerationDto ModerationDetails;
 
     /// The reactions added to the message by the current user.
     UPROPERTY()

--- a/Plugins/StreamChat/Source/Backend/StreamChatDto/Public/Response/Moderation/MessageModerationDto.h
+++ b/Plugins/StreamChat/Source/Backend/StreamChatDto/Public/Response/Moderation/MessageModerationDto.h
@@ -1,0 +1,57 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "MessageModerationDto.generated.h"
+
+/**
+ * @brief #/components/schemas/MessageModerationResult
+ * The moderation verdict the API reached for a message.
+ *
+ * Carries both the `moderation` key of Moderation V2 and the older `moderation_details` key: the two
+ * payloads have the same shape, and only their `action` vocabulary differs.
+ *
+ * @ingroup StreamChatDto
+ * @see https://getstream.io/moderation/docs/guides/bounce-message/
+ */
+USTRUCT()
+struct STREAMCHATDTO_API FMessageModerationDto
+{
+    GENERATED_BODY()
+
+    /**
+     * What moderation did with the message.
+     *
+     * Left as a string rather than an enum because the server may add actions the SDK has not been
+     * taught yet, and an unknown value must reach the caller instead of failing to parse. V2 sends
+     * `bounce`, `remove` or `flag`; V1 sends `MESSAGE_RESPONSE_ACTION_BOUNCE` and friends.
+     */
+    UPROPERTY()
+    FString Action;
+
+    /// The text the user submitted, before moderation replaced or withheld it
+    UPROPERTY()
+    FString OriginalText;
+
+    /// Harm labels the text triggered. Server-side responses only.
+    UPROPERTY()
+    TArray<FString> TextHarms;
+
+    /// Harm labels the images triggered. Server-side responses only.
+    UPROPERTY()
+    TArray<FString> ImageHarms;
+
+    /// Name of the blocklist the message matched, if any. Server-side responses only.
+    UPROPERTY()
+    FString BlocklistMatched;
+
+    /// The semantic filter phrase the message matched, if any. Server-side responses only.
+    UPROPERTY()
+    FString SemanticFilterMatched;
+
+    /// Whether the message tripped the platform circumvention model. Server-side responses only.
+    UPROPERTY()
+    bool bPlatformCircumvented = false;
+};

--- a/Plugins/StreamChat/Source/StreamChat/Private/Channel/ChatChannel.cpp
+++ b/Plugins/StreamChat/Source/StreamChat/Private/Channel/ChatChannel.cpp
@@ -481,16 +481,37 @@ void UChatChannel::SendMessage(const FMessage& Message, const TFunction<void(con
         Properties.Id,
         Request,
         false,
-        [Callback](const TResponse<FMessageResponseDto>& Response)
+        [Callback, WeakThis = TWeakObjectPtr<UChatChannel>(this)](const TResponse<FMessageResponseDto>& Response)
         {
+            bool bBounced = false;
             if (const auto* Dto = Response.Get())
             {
-                // No need to add message here as the backend will send a websocket message
-                UE_LOG(LogTemp, Log, TEXT("Sent message [Id=%s]"), *Dto->Message.Id);
+                FMessage Sent{Dto->Message, UUserManager::Get()};
+                bBounced = Sent.IsBounced();
+                if (bBounced)
+                {
+                    // A bounce is the one success response that did not publish anything, and no
+                    // websocket event follows it, so the local copy has to be corrected here or it
+                    // would sit at Sending for ever. Failed is what marks it as needing the author's
+                    // attention; the bounce verdict rode along on the DTO.
+                    Sent.State = EMessageSendState::Failed;
+                    if (WeakThis.IsValid())
+                    {
+                        WeakThis->AddMessage(Sent);
+                    }
+                    UE_LOG(LogTemp, Log, TEXT("Message bounced by moderation [Id=%s]"), *Dto->Message.Id);
+                }
+                else
+                {
+                    // No need to add message here as the backend will send a websocket message
+                    UE_LOG(LogTemp, Log, TEXT("Sent message [Id=%s]"), *Dto->Message.Id);
+                }
             }
             if (Callback)
             {
-                Callback(Response.IsSuccessful());
+                // A bounced message never reached the channel, so this was not a successful send even
+                // though the request itself succeeded
+                Callback(Response.IsSuccessful() && !bBounced);
             }
         });
     MessageSent.Broadcast(NewMessage);
@@ -535,20 +556,44 @@ void UChatChannel::UpdateMessage(const FMessage& Message)
             {
                 if (WeakThis.IsValid())
                 {
-                    WeakThis->AddMessage(FMessage{Dto->Message, UUserManager::Get()});
-                    UE_LOG(LogTemp, Log, TEXT("Updated message [Id=%s]"), *Dto->Message.Id);
+                    FMessage Updated{Dto->Message, UUserManager::Get()};
+                    if (Updated.IsBounced())
+                    {
+                        // The edit was rejected, so nothing was stored. Shown as failed for the author
+                        // to rephrase; the text on the server is still the one from before the edit,
+                        // and re-querying the channel will bring that back.
+                        Updated.State = EMessageSendState::Failed;
+                        UE_LOG(LogTemp, Log, TEXT("Message edit bounced by moderation [Id=%s]"), *Dto->Message.Id);
+                    }
+                    else
+                    {
+                        UE_LOG(LogTemp, Log, TEXT("Updated message [Id=%s]"), *Dto->Message.Id);
+                    }
+                    WeakThis->AddMessage(Updated);
                 }
             }
         });
     // TODO retry?
 }
 
+void UChatChannel::ResendMessage(const FMessage& Message)
+{
+    FMessage Resent = Message;
+    Resent.Moderation = FMessageModeration{};
+    if (Resent.Type == EMessageType::Error)
+    {
+        Resent.Type = EMessageType::Regular;
+    }
+    SendMessage(Resent);
+}
+
 void UChatChannel::DeleteMessage(const FMessage& Message)
 {
     // TODO Attachments
 
-    // Directly deleting the local messages which are not yet sent to server
-    if (Message.State == EMessageSendState::Sending || Message.State == EMessageSendState::Failed)
+    // Directly deleting the local messages which are not yet sent to server. A bounced message is one
+    // of those: moderation does not store it, so the delete endpoint would not find it.
+    if (Message.State == EMessageSendState::Sending || Message.State == EMessageSendState::Failed || Message.IsBounced())
     {
         FMessage DeletedMessage = Message;
         DeletedMessage.Type = EMessageType::Deleted;

--- a/Plugins/StreamChat/Source/StreamChat/Private/Channel/Message.cpp
+++ b/Plugins/StreamChat/Source/StreamChat/Private/Channel/Message.cpp
@@ -7,6 +7,26 @@
 #include "Response/Message/MessageDto.h"
 #include "User/UserManager.h"
 
+namespace
+{
+/**
+ * Pick the moderation verdict out of a message DTO.
+ *
+ * An app configured for Moderation V2 gets its verdict in `moderation`, and one still on the older
+ * API gets it in `moderation_details`. Only ever one of the two arrives, so preferring the newer
+ * field and falling back covers both without the caller having to care which is in use.
+ */
+FMessageModeration PickModeration(const FMessageDto& Dto)
+{
+    const FMessageModeration V2{Dto.Moderation};
+    if (V2.IsSet())
+    {
+        return V2;
+    }
+    return FMessageModeration{Dto.ModerationDetails};
+}
+}    // namespace
+
 FMessage::FMessage() = default;
 
 FMessage::FMessage(const FMessageDto& Dto, UUserManager* UserManager)
@@ -26,6 +46,7 @@ FMessage::FMessage(const FMessageDto& Dto, UUserManager* UserManager)
     , ThreadParticipants{UserManager->UpsertUsers(Dto.ThreadParticipants)}
     , bIsSilent{Dto.bSilent}
     , bIsShadowed{Dto.bShadowed}
+    , Moderation{PickModeration(Dto)}
     , Html{Dto.Html}
     , ExtraData{Dto.AdditionalFields}
 {
@@ -67,4 +88,19 @@ bool FMessage::IsThreadReply() const
 bool FMessage::IsThreadStart() const
 {
     return ReplyCount > 0;
+}
+
+bool FMessage::IsBounced() const
+{
+    return Moderation.Action == EMessageModerationAction::Bounce;
+}
+
+bool FMessage::IsRemovedByModeration() const
+{
+    return Moderation.Action == EMessageModerationAction::Remove;
+}
+
+bool FMessage::IsModerationError() const
+{
+    return IsBounced() && Type == EMessageType::Error && User.IsCurrent();
 }

--- a/Plugins/StreamChat/Source/StreamChat/Private/Moderation/MessageModeration.cpp
+++ b/Plugins/StreamChat/Source/StreamChat/Private/Moderation/MessageModeration.cpp
@@ -1,0 +1,51 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#include "Moderation/MessageModeration.h"
+
+namespace
+{
+/**
+ * Translate the API's action name to the enum.
+ *
+ * Both moderation versions land here. Their vocabularies do not overlap, so one lookup covers each:
+ * V2 sends lowercase names, and V1 sends SCREAMING_SNAKE ones. V1's "block" is V2's "remove", which
+ * is the one pair whose names disagree.
+ */
+EMessageModerationAction ParseAction(const FString& Action)
+{
+    if (Action.IsEmpty())
+    {
+        return EMessageModerationAction::None;
+    }
+    if (Action.Equals(TEXT("bounce"), ESearchCase::IgnoreCase) || Action.Equals(TEXT("MESSAGE_RESPONSE_ACTION_BOUNCE"), ESearchCase::IgnoreCase))
+    {
+        return EMessageModerationAction::Bounce;
+    }
+    if (Action.Equals(TEXT("remove"), ESearchCase::IgnoreCase) || Action.Equals(TEXT("MESSAGE_RESPONSE_ACTION_BLOCK"), ESearchCase::IgnoreCase))
+    {
+        return EMessageModerationAction::Remove;
+    }
+    if (Action.Equals(TEXT("flag"), ESearchCase::IgnoreCase) || Action.Equals(TEXT("MESSAGE_RESPONSE_ACTION_FLAG"), ESearchCase::IgnoreCase))
+    {
+        return EMessageModerationAction::Flag;
+    }
+    return EMessageModerationAction::Other;
+}
+}    // namespace
+
+FMessageModeration::FMessageModeration(const FMessageModerationDto& Dto)
+    : Action{ParseAction(Dto.Action)}
+    , RawAction{Dto.Action}
+    , OriginalText{Dto.OriginalText}
+    , TextHarms{Dto.TextHarms}
+    , ImageHarms{Dto.ImageHarms}
+    , BlocklistMatched{Dto.BlocklistMatched}
+    , SemanticFilterMatched{Dto.SemanticFilterMatched}
+    , bPlatformCircumvented{Dto.bPlatformCircumvented}
+{
+}
+
+bool FMessageModeration::IsSet() const
+{
+    return Action != EMessageModerationAction::None;
+}

--- a/Plugins/StreamChat/Source/StreamChat/Private/Moderation/UserBlock.cpp
+++ b/Plugins/StreamChat/Source/StreamChat/Private/Moderation/UserBlock.cpp
@@ -1,0 +1,12 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#include "Moderation/UserBlock.h"
+
+#include "User/UserManager.h"
+
+FUserBlock::FUserBlock(const FBlockedUserDto& Dto, UUserManager* UserManager)
+    : BlockedUser{UserManager->UpsertUser(Dto.BlockedUser)}
+    , BlockedBy{UserManager->UpsertUser(Dto.User)}
+    , CreatedAt{Dto.CreatedAt}
+{
+}

--- a/Plugins/StreamChat/Source/StreamChat/Private/StreamChatClientComponent.cpp
+++ b/Plugins/StreamChat/Source/StreamChat/Private/StreamChatClientComponent.cpp
@@ -19,6 +19,7 @@
 #include "Response/Channel/ChannelsResponseDto.h"
 #include "Response/Device/ListDevicesResponseDto.h"
 #include "Response/Message/SearchResponseDto.h"
+#include "Response/Moderation/BlockUserResponseDto.h"
 #include "Response/Moderation/GetBlockedUsersResponseDto.h"
 #include "Response/Moderation/MuteUserResponseDto.h"
 #include "Response/Moderation/QueryBannedUsersResponseDto.h"
@@ -631,14 +632,34 @@ void UStreamChatClientComponent::ListDevices(TFunction<void(TArray<FDevice>)> Ca
         });
 }
 
-void UStreamChatClientComponent::FlagMessage(const FMessage& Message) const
+void UStreamChatClientComponent::FlagMessage(const FMessage& Message, const FString& Reason, const TMap<FString, FString>& CustomData) const
 {
-    Api->Flag(Message.Id);
+    Api->Flag(Message.Id, {}, Reason, CustomData);
 }
 
-void UStreamChatClientComponent::FlagUser(const FUserRef& User) const
+void UStreamChatClientComponent::FlagMessage(const FMessage& Message, const FString& Reason) const
 {
-    Api->Flag({}, User->Id);
+    FlagMessage(Message, Reason, {});
+}
+
+void UStreamChatClientComponent::UnflagMessage(const FMessage& Message) const
+{
+    Api->Unflag(Message.Id);
+}
+
+void UStreamChatClientComponent::FlagUser(const FUserRef& User, const FString& Reason, const TMap<FString, FString>& CustomData) const
+{
+    Api->Flag({}, User->Id, Reason, CustomData);
+}
+
+void UStreamChatClientComponent::FlagUser(const FUserRef& User, const FString& Reason) const
+{
+    FlagUser(User, Reason, {});
+}
+
+void UStreamChatClientComponent::UnflagUser(const FUserRef& User) const
+{
+    Api->Unflag({}, User->Id);
 }
 
 void UStreamChatClientComponent::MuteUserBP(const FUserRef& User, const FTimespan Timeout) const
@@ -659,27 +680,51 @@ void UStreamChatClientComponent::UnmuteUser(const FUserRef& User) const
 
 void UStreamChatClientComponent::BlockUser(const FUserRef& User) const
 {
-    Api->BlockUser(User->Id);
+    Api->BlockUser(
+        User->Id,
+        [UserId = User->Id](const TResponse<FBlockUserResponseDto>& Response)
+        {
+            // No event reports a block, so the local list is the only record of one
+            if (Response.IsSuccessful())
+            {
+                UUserManager::Get()->SetUserBlocked(UserId, true);
+            }
+        });
 }
 
 void UStreamChatClientComponent::UnblockUser(const FUserRef& User) const
 {
-    Api->UnblockUser(User->Id);
+    Api->UnblockUser(
+        User->Id,
+        [UserId = User->Id](const TResponse<FResponseDto>& Response)
+        {
+            if (Response.IsSuccessful())
+            {
+                UUserManager::Get()->SetUserBlocked(UserId, false);
+            }
+        });
 }
 
-void UStreamChatClientComponent::GetBlockedUsers(TFunction<void(const TArray<FString>&)> Callback) const
+void UStreamChatClientComponent::GetBlockedUsers(TFunction<void(const TArray<FUserBlock>&)> Callback) const
 {
     Api->GetBlockedUsers(
         [Callback](const TResponse<FGetBlockedUsersResponseDto>& Response)
         {
-            TArray<FString> BlockedUserIds;
-            for (const FBlockedUserDto& Block : Response.GetRef().Blocks)
+            if (!Response.IsSuccessful())
             {
-                BlockedUserIds.Add(Block.BlockedUserId);
+                return;
             }
+
+            UUserManager* UserManager = UUserManager::Get();
+            const TArray<FUserBlock> Blocks = Util::Convert<FUserBlock>(Response.GetRef().Blocks, UserManager);
+
+            TArray<FString> BlockedUserIds;
+            Algo::Transform(Blocks, BlockedUserIds, [](const FUserBlock& Block) { return Block.BlockedUser->Id; });
+            UserManager->SetBlockedUserIds(BlockedUserIds);
+
             if (Callback)
             {
-                Callback(BlockedUserIds);
+                Callback(Blocks);
             }
         });
 }

--- a/Plugins/StreamChat/Source/StreamChat/Private/Tests/MessageModeration.spec.cpp
+++ b/Plugins/StreamChat/Source/StreamChat/Private/Tests/MessageModeration.spec.cpp
@@ -1,0 +1,187 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#include "Moderation/MessageModeration.h"
+
+#include "Channel/Message.h"
+#include "Misc/AutomationTest.h"
+#include "Response/Message/MessageDto.h"
+#include "Response/Moderation/MessageModerationDto.h"
+#include "User/UserManager.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+BEGIN_DEFINE_SPEC(
+    FMessageModerationSpec,
+    "StreamChat.MessageModeration",
+    EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
+END_DEFINE_SPEC(FMessageModerationSpec)
+
+void FMessageModerationSpec::Define()
+{
+    Describe(
+        "Moderation V2 actions",
+        [this]
+        {
+            It("should read a bounce",
+               [this]
+               {
+                   FMessageModerationDto Dto;
+                   Dto.Action = TEXT("bounce");
+                   Dto.OriginalText = TEXT("something rude");
+
+                   const FMessageModeration Moderation{Dto};
+                   TestEqual("Action", Moderation.Action, EMessageModerationAction::Bounce);
+                   TestTrue("Set", Moderation.IsSet());
+                   TestEqual("Original text kept", Moderation.OriginalText, TEXT("something rude"));
+               });
+
+            It("should read a remove",
+               [this]
+               {
+                   FMessageModerationDto Dto;
+                   Dto.Action = TEXT("remove");
+                   TestEqual("Action", FMessageModeration{Dto}.Action, EMessageModerationAction::Remove);
+               });
+
+            It("should read a flag",
+               [this]
+               {
+                   FMessageModerationDto Dto;
+                   Dto.Action = TEXT("flag");
+                   TestEqual("Action", FMessageModeration{Dto}.Action, EMessageModerationAction::Flag);
+               });
+        });
+
+    Describe(
+        "Moderation V1 actions",
+        [this]
+        {
+            It("should read a bounce",
+               [this]
+               {
+                   FMessageModerationDto Dto;
+                   Dto.Action = TEXT("MESSAGE_RESPONSE_ACTION_BOUNCE");
+                   TestEqual("Action", FMessageModeration{Dto}.Action, EMessageModerationAction::Bounce);
+               });
+
+            It("should read a block as a remove",
+               [this]
+               {
+                   // The one action the two versions disagree on the name of
+                   FMessageModerationDto Dto;
+                   Dto.Action = TEXT("MESSAGE_RESPONSE_ACTION_BLOCK");
+                   TestEqual("Action", FMessageModeration{Dto}.Action, EMessageModerationAction::Remove);
+               });
+
+            It("should read a flag",
+               [this]
+               {
+                   FMessageModerationDto Dto;
+                   Dto.Action = TEXT("MESSAGE_RESPONSE_ACTION_FLAG");
+                   TestEqual("Action", FMessageModeration{Dto}.Action, EMessageModerationAction::Flag);
+               });
+        });
+
+    Describe(
+        "Unrecognised verdicts",
+        [this]
+        {
+            It("should report no verdict when the API sent none",
+               [this]
+               {
+                   const FMessageModeration Moderation{FMessageModerationDto{}};
+                   TestEqual("Action", Moderation.Action, EMessageModerationAction::None);
+                   TestFalse("Not set", Moderation.IsSet());
+               });
+
+            It("should keep an action it does not know, rather than dropping it",
+               [this]
+               {
+                   // A new server-side action must still reach the caller: this is the whole reason the
+                   // DTO holds the action as a string rather than as an enum
+                   FMessageModerationDto Dto;
+                   Dto.Action = TEXT("some_future_action");
+
+                   const FMessageModeration Moderation{Dto};
+                   TestEqual("Action", Moderation.Action, EMessageModerationAction::Other);
+                   TestTrue("Set", Moderation.IsSet());
+                   TestEqual("Raw action kept", Moderation.RawAction, TEXT("some_future_action"));
+               });
+        });
+
+    Describe(
+        "A moderated message",
+        [this]
+        {
+            It("should prefer the V2 verdict when the API sent both",
+               [this]
+               {
+                   // An app is on one moderation version or the other, so both keys arriving at once is
+                   // not something the API does. Pinned anyway because the fallback has to be ordered:
+                   // reading V1 first would mask the newer verdict.
+                   FMessageDto Dto;
+                   Dto.Moderation.Action = TEXT("bounce");
+                   Dto.ModerationDetails.Action = TEXT("MESSAGE_RESPONSE_ACTION_FLAG");
+
+                   const FMessage Message{Dto, UUserManager::Get()};
+                   TestEqual("Action", Message.Moderation.Action, EMessageModerationAction::Bounce);
+                   TestTrue("Bounced", Message.IsBounced());
+               });
+
+            It("should fall back to the V1 verdict",
+               [this]
+               {
+                   FMessageDto Dto;
+                   Dto.ModerationDetails.Action = TEXT("MESSAGE_RESPONSE_ACTION_BOUNCE");
+
+                   const FMessage Message{Dto, UUserManager::Get()};
+                   TestEqual("Action", Message.Moderation.Action, EMessageModerationAction::Bounce);
+                   TestTrue("Bounced", Message.IsBounced());
+               });
+
+            It("should report no verdict for the ordinary message",
+               [this]
+               {
+                   const FMessageDto Dto;
+                   const FMessage Message{Dto, UUserManager::Get()};
+                   TestFalse("Not moderated", Message.Moderation.IsSet());
+                   TestFalse("Not bounced", Message.IsBounced());
+                   TestFalse("Not removed", Message.IsRemovedByModeration());
+                   TestFalse("Not a moderation error", Message.IsModerationError());
+               });
+
+            It("should tell a removed message from a bounced one",
+               [this]
+               {
+                   FMessage Message{TEXT("hi")};
+                   Message.Moderation.Action = EMessageModerationAction::Remove;
+
+                   TestFalse("Not bounced", Message.IsBounced());
+                   TestTrue("Removed", Message.IsRemovedByModeration());
+                   // Only a bounce is the author's to do something about
+                   TestFalse("Not a moderation error", Message.IsModerationError());
+               });
+        });
+
+    It("should carry the harm labels of a server side response",
+       [this]
+       {
+           FMessageModerationDto Dto;
+           Dto.Action = TEXT("remove");
+           Dto.TextHarms = {TEXT("HARM_HATE"), TEXT("HARM_HARASSMENT")};
+           Dto.ImageHarms = {TEXT("HARM_NUDITY")};
+           Dto.BlocklistMatched = TEXT("profanity_en_2020_v1");
+           Dto.SemanticFilterMatched = TEXT("no self harm");
+           Dto.bPlatformCircumvented = true;
+
+           const FMessageModeration Moderation{Dto};
+           TestEqual("Text harms", Moderation.TextHarms.Num(), 2);
+           TestEqual("First text harm", Moderation.TextHarms[0], TEXT("HARM_HATE"));
+           TestEqual("Image harms", Moderation.ImageHarms.Num(), 1);
+           TestEqual("Blocklist", Moderation.BlocklistMatched, TEXT("profanity_en_2020_v1"));
+           TestEqual("Semantic filter", Moderation.SemanticFilterMatched, TEXT("no self harm"));
+           TestTrue("Platform circumvented", Moderation.bPlatformCircumvented);
+       });
+}
+
+#endif    // WITH_DEV_AUTOMATION_TESTS

--- a/Plugins/StreamChat/Source/StreamChat/Private/User/OwnUser.cpp
+++ b/Plugins/StreamChat/Source/StreamChat/Private/User/OwnUser.cpp
@@ -29,9 +29,16 @@ void FOwnUser::Update(const FOwnUser& OwnUser)
     UnreadChannels = OwnUser.UnreadChannels;
     MutedUsers = OwnUser.MutedUsers;
     MutedChannels = OwnUser.MutedChannels;
+    // Deliberately not BlockedUserIds: the own user payload this was built from never carries them,
+    // so copying would clear what the block endpoints told us.
 }
 
 bool FOwnUser::HasMutedUser(const FUserRef& TargetUser) const
 {
     return MutedUsers.ContainsByPredicate([&TargetUser](const FMutedUser& M) { return M.Target == TargetUser; });
+}
+
+bool FOwnUser::HasBlockedUser(const FUserRef& TargetUser) const
+{
+    return BlockedUserIds.Contains(TargetUser->Id);
 }

--- a/Plugins/StreamChat/Source/StreamChat/Private/User/UserManager.cpp
+++ b/Plugins/StreamChat/Source/StreamChat/Private/User/UserManager.cpp
@@ -113,6 +113,40 @@ FUserUpdatedMultiDelegate& UUserManager::OnUserUpdated(const FUserRef& Ref)
 
 const FOwnUser& UUserManager::SetCurrentUser(const FOwnUserDto& Dto)
 {
+    // Carried over by hand because the own user payload has no blocked users in it, and this runs
+    // again every time the mute lists change. Rebuilding from the DTO alone would drop them.
+    TArray<FString> BlockedUserIds;
+    if (CurrentUser.IsSet())
+    {
+        BlockedUserIds = MoveTemp(CurrentUser->BlockedUserIds);
+    }
+
     CurrentUser.Emplace(Dto, this);
+    CurrentUser->BlockedUserIds = MoveTemp(BlockedUserIds);
     return CurrentUser.GetValue();
+}
+
+void UUserManager::SetBlockedUserIds(const TArray<FString>& BlockedUserIds)
+{
+    if (CurrentUser.IsSet())
+    {
+        CurrentUser->BlockedUserIds = BlockedUserIds;
+    }
+}
+
+void UUserManager::SetUserBlocked(const FString& UserId, const bool bBlocked)
+{
+    if (!CurrentUser.IsSet())
+    {
+        return;
+    }
+
+    if (bBlocked)
+    {
+        CurrentUser->BlockedUserIds.AddUnique(UserId);
+    }
+    else
+    {
+        CurrentUser->BlockedUserIds.Remove(UserId);
+    }
 }

--- a/Plugins/StreamChat/Source/StreamChat/Public/Channel/ChatChannel.h
+++ b/Plugins/StreamChat/Source/StreamChat/Public/Channel/ChatChannel.h
@@ -331,7 +331,25 @@ public:
     void UpdateMessage(const FMessage& Message);
 
     /**
+     * @brief Send a message again, after a first attempt did not reach the channel
+     *
+     * Written for a message moderation bounced: that message was never stored server side, so it has
+     * to be sent afresh rather than edited. The previous verdict and error type are cleared, so the
+     * message stops reading as rejected while the new attempt is in flight.
+     *
+     * Sending the same text again will usually be bounced again. Let the author edit it first, unless
+     * your moderation rules are configured to let a resend through.
+     *
+     * @param Message Message held by this channel which failed to send
+     */
+    UFUNCTION(BlueprintCallable, Category = "Stream Chat|Channel|Message")
+    void ResendMessage(const FMessage& Message);
+
+    /**
      * @brief Soft delete a message in this channel
+     *
+     * A message which never reached the server, including one moderation bounced, is only removed
+     * locally: there is nothing on the server to delete.
      *
      * @param Message Message which already exists in this channel
      */

--- a/Plugins/StreamChat/Source/StreamChat/Public/Channel/Message.h
+++ b/Plugins/StreamChat/Source/StreamChat/Public/Channel/Message.h
@@ -4,6 +4,7 @@
 
 #include "Channel/Attachment.h"
 #include "CoreMinimal.h"
+#include "Moderation/MessageModeration.h"
 #include "Reaction/Reactions.h"
 #include "Response/Channel/ChannelStateResponseFieldsDto.h"
 #include "Response/Message/SearchResultDto.h"
@@ -85,6 +86,25 @@ struct STREAMCHAT_API FMessage
     /// Does this message have a thread of replies hanging off it?
     bool IsThreadStart() const;
 
+    /**
+     * @brief Did moderation bounce this message back to be rephrased?
+     *
+     * A bounced message was never published and is not stored server side, so it exists only in this
+     * client's message list. Offer the author the chance to edit and send it again, or to discard it.
+     */
+    bool IsBounced() const;
+
+    /// Did moderation block this message and take it out of the channel?
+    bool IsRemovedByModeration() const;
+
+    /**
+     * @brief Is this the current user's own message, sitting in the list because moderation bounced it?
+     *
+     * The API reports a bounce as an error-type message, which is how it is told apart from a message
+     * that failed to send for some other reason.
+     */
+    bool IsModerationError() const;
+
     /// The message ID. This is either created by the Stream API or set client side when the message is created.
     UPROPERTY()
     FString Id;
@@ -148,6 +168,10 @@ struct STREAMCHAT_API FMessage
     /// Whether the message was shadowed or not
     UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Stream Chat|Message", AdvancedDisplay)
     bool bIsShadowed = false;
+
+    /// What moderation decided about this message. Unset on all but a handful of messages.
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Stream Chat|Message", AdvancedDisplay)
+    FMessageModeration Moderation;
 
     /// Contains HTML markup of the message
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Stream Chat|Message")

--- a/Plugins/StreamChat/Source/StreamChat/Public/Moderation/MessageModeration.h
+++ b/Plugins/StreamChat/Source/StreamChat/Public/Moderation/MessageModeration.h
@@ -1,0 +1,87 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Response/Moderation/MessageModerationDto.h"
+
+#include "MessageModeration.generated.h"
+
+/**
+ * @brief What moderation decided to do with a message
+ * @ingroup StreamChat
+ */
+UENUM(BlueprintType)
+enum class EMessageModerationAction : uint8
+{
+    /// Moderation reached no verdict, which is the case for almost every message
+    None,
+    /// The message needs rephrasing and sending again. It was neither published nor stored.
+    Bounce,
+    /// The message was blocked and removed from the channel.
+    Remove,
+    /// The message was published, but sent to the dashboard for a moderator to review.
+    Flag,
+    /// An action this version of the SDK does not know about. Read FMessageModeration::RawAction.
+    Other
+};
+
+/**
+ * @brief The moderation verdict for a message
+ *
+ * Populated from the `moderation` field of Moderation V2, falling back to the older
+ * `moderation_details` field, whose action names are translated to the same enum.
+ *
+ * Only Action and OriginalText come back on a client-side response. The harm labels below are
+ * included in server-side responses only, so expect them to be empty in a game.
+ *
+ * @ingroup StreamChat
+ */
+USTRUCT(BlueprintType)
+struct STREAMCHAT_API FMessageModeration
+{
+    GENERATED_BODY()
+
+    FMessageModeration() = default;
+    explicit FMessageModeration(const FMessageModerationDto&);
+
+    /// Did moderation reach a verdict on this message at all?
+    bool IsSet() const;
+
+    /// What moderation did with the message
+    UPROPERTY(BlueprintReadOnly, Category = "Stream|Moderation")
+    EMessageModerationAction Action = EMessageModerationAction::None;
+
+    /**
+     * @brief The action exactly as the API named it
+     *
+     * The only way to tell one Other action from another, and the only way to read an action added
+     * to the API after this version of the SDK was built.
+     */
+    UPROPERTY(BlueprintReadOnly, Category = "Stream|Moderation")
+    FString RawAction;
+
+    /// The text the user submitted, before moderation replaced or withheld it
+    UPROPERTY(BlueprintReadOnly, Category = "Stream|Moderation")
+    FString OriginalText;
+
+    /// Harm labels the text triggered. Server-side responses only.
+    UPROPERTY(BlueprintReadOnly, Category = "Stream|Moderation")
+    TArray<FString> TextHarms;
+
+    /// Harm labels the images triggered. Server-side responses only.
+    UPROPERTY(BlueprintReadOnly, Category = "Stream|Moderation")
+    TArray<FString> ImageHarms;
+
+    /// Name of the blocklist the message matched, if any. Server-side responses only.
+    UPROPERTY(BlueprintReadOnly, Category = "Stream|Moderation")
+    FString BlocklistMatched;
+
+    /// The semantic filter phrase the message matched, if any. Server-side responses only.
+    UPROPERTY(BlueprintReadOnly, Category = "Stream|Moderation")
+    FString SemanticFilterMatched;
+
+    /// Whether the message tripped the platform circumvention model. Server-side responses only.
+    UPROPERTY(BlueprintReadOnly, Category = "Stream|Moderation")
+    bool bPlatformCircumvented = false;
+};

--- a/Plugins/StreamChat/Source/StreamChat/Public/Moderation/UserBlock.h
+++ b/Plugins/StreamChat/Source/StreamChat/Public/Moderation/UserBlock.h
@@ -1,0 +1,40 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Response/Moderation/GetBlockedUsersResponseDto.h"
+#include "User/UserRef.h"
+
+#include "UserBlock.generated.h"
+
+class UUserManager;
+
+/**
+ * @brief One user blocking another
+ *
+ * Blocking hides every 1-on-1 channel the two share from the blocking user, and stops the blocked
+ * user's events and push notifications reaching them. Group channels are unaffected.
+ *
+ * @ingroup StreamChat
+ */
+USTRUCT(BlueprintType)
+struct STREAMCHAT_API FUserBlock
+{
+    GENERATED_BODY()
+
+    FUserBlock() = default;
+    explicit FUserBlock(const FBlockedUserDto&, UUserManager*);
+
+    /// The user who was blocked
+    UPROPERTY(BlueprintReadOnly, Category = "Stream|Moderation")
+    FUserRef BlockedUser;
+
+    /// The user who created the block, which for anything a client can query is the current user
+    UPROPERTY(BlueprintReadOnly, Category = "Stream|Moderation")
+    FUserRef BlockedBy;
+
+    /// When the block was created
+    UPROPERTY(BlueprintReadOnly, Category = "Stream|Moderation")
+    FDateTime CreatedAt = FDateTime{0};
+};

--- a/Plugins/StreamChat/Source/StreamChat/Public/StreamChatClientComponent.h
+++ b/Plugins/StreamChat/Source/StreamChat/Public/StreamChatClientComponent.h
@@ -15,6 +15,7 @@
 #include "Event/Notification/NotificationMutesUpdatedEvent.h"
 #include "IChatSocket.h"
 #include "Moderation/BanPaginationOptions.h"
+#include "Moderation/UserBlock.h"
 #include "PaginationOptions.h"
 #include "Templates/IsInvocable.h"
 #include "User/OwnUser.h"
@@ -479,18 +480,48 @@ public:
     /**
      * @brief Flag message for moderation
      *
+     * The flagged message reaches the review queue in the moderation dashboard. Flagging does not
+     * hide the message: that is a moderator's decision, or an automod rule's.
+     *
+     * @param Message A reference to an existing message
+     * @param Reason Why the message was reported. Shown to moderators in the review queue. (optional)
+     * @param CustomData Extra key/value pairs to attach to the flag (optional)
+     */
+    UFUNCTION(BlueprintCallable, BlueprintPure = false, Category = "Stream Chat|Client|Moderation")
+    void FlagMessage(const FMessage& Message, const FString& Reason, const TMap<FString, FString>& CustomData) const;
+
+    /// Overload rather than a default argument, because UHT cannot parse a default value for a TMap
+    /// parameter, and giving the Blueprint-facing function a different name would rename its node.
+    void FlagMessage(const FMessage& Message, const FString& Reason = TEXT("")) const;
+
+    /**
+     * @brief Withdraw a flag this user previously raised against a message
+     *
      * @param Message A reference to an existing message
      */
-    UFUNCTION(BlueprintCallable, BlueprintPure = false, Category = "Stream Chat|Client")
-    void FlagMessage(const FMessage& Message) const;
+    UFUNCTION(BlueprintCallable, BlueprintPure = false, Category = "Stream Chat|Client|Moderation")
+    void UnflagMessage(const FMessage& Message) const;
 
     /**
      * @brief Flag user for moderation
      *
      * @param User A reference to a user
+     * @param Reason Why the user was reported. Shown to moderators in the review queue. (optional)
+     * @param CustomData Extra key/value pairs to attach to the flag (optional)
      */
-    UFUNCTION(BlueprintCallable, BlueprintPure = false, Category = "Stream Chat|Client")
-    void FlagUser(const FUserRef& User) const;
+    UFUNCTION(BlueprintCallable, BlueprintPure = false, Category = "Stream Chat|Client|Moderation")
+    void FlagUser(const FUserRef& User, const FString& Reason, const TMap<FString, FString>& CustomData) const;
+
+    /// Overload rather than a default argument, for the same reason as FlagMessage
+    void FlagUser(const FUserRef& User, const FString& Reason = TEXT("")) const;
+
+    /**
+     * @brief Withdraw a flag this user previously raised against another user
+     *
+     * @param User A reference to a user
+     */
+    UFUNCTION(BlueprintCallable, BlueprintPure = false, Category = "Stream Chat|Client|Moderation")
+    void UnflagUser(const FUserRef& User) const;
 
     /**
      * @brief Mute the given user
@@ -532,9 +563,13 @@ public:
     /**
      * @brief Get the users blocked by the currently connected user
      *
-     * @param Callback Called with the ids of the blocked users
+     * Also refreshes FOwnUser::BlockedUserIds, which nothing else populates: the API reports blocks
+     * only here and in the block/unblock responses. Call this once after connecting if you rely on
+     * FOwnUser::HasBlockedUser.
+     *
+     * @param Callback Called with the blocks created by the current user
      */
-    void GetBlockedUsers(TFunction<void(const TArray<FString>&)> Callback) const;
+    void GetBlockedUsers(TFunction<void(const TArray<FUserBlock>&)> Callback = {}) const;
 
     ///@}
 #pragma endregion Moderation

--- a/Plugins/StreamChat/Source/StreamChat/Public/User/OwnUser.h
+++ b/Plugins/StreamChat/Source/StreamChat/Public/User/OwnUser.h
@@ -30,6 +30,9 @@ struct STREAMCHAT_API FOwnUser
     /// Has this user muted the given user?
     bool HasMutedUser(const FUserRef& TargetUser) const;
 
+    /// Has this user blocked the given user?
+    bool HasBlockedUser(const FUserRef& TargetUser) const;
+
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Stream Chat|User")
     FUserRef User;
 
@@ -51,4 +54,16 @@ struct STREAMCHAT_API FOwnUser
     /// Only populated for current user
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Stream Chat|User")
     TArray<FMutedChannel> MutedChannels;
+
+    /**
+     * @brief Ids of the users this user has blocked
+     *
+     * Unlike the mute lists, this is not part of the own user the API sends down, and no event
+     * reports a change to it. It is maintained from the responses to
+     * UStreamChatClientComponent::BlockUser, UnblockUser and GetBlockedUsers, so it is only as
+     * complete as the calls this session has made. Call GetBlockedUsers once after connecting to
+     * populate it.
+     */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Stream Chat|User")
+    TArray<FString> BlockedUserIds;
 };

--- a/Plugins/StreamChat/Source/StreamChat/Public/User/UserManager.h
+++ b/Plugins/StreamChat/Source/StreamChat/Public/User/UserManager.h
@@ -34,6 +34,18 @@ public:
     FUserUpdatedMultiDelegate& OnUserUpdated(const FUserRef&);
 
     const FOwnUser& SetCurrentUser(const FOwnUserDto& Dto);
+
+    /**
+     * @brief Record the full set of users the current user has blocked
+     *
+     * The API reports blocks only in the response to the block endpoints, never in the own user
+     * payload or in an event, so the current user's list is kept up to date from here.
+     */
+    void SetBlockedUserIds(const TArray<FString>& BlockedUserIds);
+
+    /// Record that the current user has blocked or unblocked one user
+    void SetUserBlocked(const FString& UserId, bool bBlocked);
+
     void ResetCurrentUser();
     bool HasCurrentUser() const;
     UFUNCTION(BlueprintPure, Category = "Stream|Users")

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/ContextMenu/ContextMenuWidget.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/ContextMenu/ContextMenuWidget.cpp
@@ -2,6 +2,7 @@
 
 #include "ContextMenu/ContextMenuWidget.h"
 
+#include "ContextMenu/ResendMessageContextMenuAction.h"
 #include "ContextMenu/ThreadReplyContextMenuAction.h"
 
 void UContextMenuWidget::Setup(const FMessage& InMessage, const EMessageSide InSide)
@@ -15,6 +16,16 @@ void UContextMenuWidget::Setup(const FMessage& InMessage, const EMessageSide InS
 void UContextMenuWidget::SetHeaderContent(UWidget* Content)
 {
     HeaderContent = Content;
+}
+
+template <class TAction>
+void UContextMenuWidget::AddMissingAction()
+{
+    if (Actions.ContainsByPredicate([](const UContextMenuAction* Action) { return Action && Action->IsA<TAction>(); }))
+    {
+        return;
+    }
+    Actions.Insert(NewObject<TAction>(this), 0);
 }
 
 void UContextMenuWidget::AddButton(UContextMenuAction* Action, const EContextMenuButtonPosition Position)
@@ -37,12 +48,14 @@ void UContextMenuWidget::NativePreConstruct()
         return;
     }
 
-    // WBP_ContextMenu was authored before threads existed and has no entry for replying in one, so it
-    // is added here rather than by editing the asset. Guarded so repeated pre-constructs do not stack
-    // up copies, and kept out of the editor preview, which shows the asset's own list.
-    if (!IsDesignTime() && !Actions.ContainsByPredicate([](const UContextMenuAction* A) { return A && A->IsA<UThreadReplyContextMenuAction>(); }))
+    // WBP_ContextMenu was authored before threads and moderation bounces existed and has no entry for
+    // either, so they are added here rather than by editing the asset. Guarded so repeated
+    // pre-constructs do not stack up copies, and kept out of the editor preview, which shows the
+    // asset's own list.
+    if (!IsDesignTime())
     {
-        Actions.Insert(NewObject<UThreadReplyContextMenuAction>(this), 0);
+        AddMissingAction<UThreadReplyContextMenuAction>();
+        AddMissingAction<UResendMessageContextMenuAction>();
     }
 
     for (UContextMenuAction* Action : Actions)

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/ContextMenu/ResendMessageContextMenuAction.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/ContextMenu/ResendMessageContextMenuAction.cpp
@@ -1,0 +1,25 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#include "ContextMenu/ResendMessageContextMenuAction.h"
+
+#include "Channel/ChatChannel.h"
+
+UResendMessageContextMenuAction::UResendMessageContextMenuAction()
+{
+    Label = NSLOCTEXT("StreamChat", "ResendMessageAction", "Send anyway");
+}
+
+void UResendMessageContextMenuAction::OnPerform(const FMessage& Message, UWidget* OwningWidget)
+{
+    if (Channel)
+    {
+        Channel->ResendMessage(Message);
+    }
+}
+
+bool UResendMessageContextMenuAction::OnShouldDisplay(const EMessageSide, const FMessage& Message) const
+{
+    // Only a bounced message can be sent again: anything else either reached the channel already or
+    // failed for a reason resending will not fix.
+    return Message.IsModerationError();
+}

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/ContextMenu/ThreadReplyContextMenuAction.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/ContextMenu/ThreadReplyContextMenuAction.cpp
@@ -19,6 +19,7 @@ void UThreadReplyContextMenuAction::OnPerform(const FMessage& Message, UWidget* 
 
 bool UThreadReplyContextMenuAction::OnShouldDisplay(EMessageSide, const FMessage& Message) const
 {
-    // Threads do not nest, and a deleted message has nothing to reply to
-    return !Message.IsThreadReply() && Message.Type != EMessageType::Deleted;
+    // Threads do not nest, and a deleted message has nothing to reply to. Neither has a bounced one:
+    // moderation did not store it, so there is no message for a thread to hang off.
+    return !Message.IsThreadReply() && Message.Type != EMessageType::Deleted && !Message.IsBounced();
 }

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/Input/MessageComposerWidget.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/Input/MessageComposerWidget.cpp
@@ -433,7 +433,16 @@ void UMessageComposerWidget::SendMessage()
     if (EditedMessage)
     {
         EditedMessage->Text = Text;
-        Channel->UpdateMessage(*EditedMessage);
+        if (EditedMessage->IsBounced())
+        {
+            // Moderation never stored the bounced message, so there is nothing on the server to edit.
+            // The rephrased text goes out as a fresh attempt instead.
+            Channel->ResendMessage(*EditedMessage);
+        }
+        else
+        {
+            Channel->UpdateMessage(*EditedMessage);
+        }
         StopEditMessage();
     }
     else

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/Message/MessageHoverMenuWidget.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/Message/MessageHoverMenuWidget.cpp
@@ -75,6 +75,13 @@ void UMessageHoverMenuWidget::OnSetup()
     if (ReactionMenuAnchor)
     {
         ReactionMenuAnchor->SetPlacement(MenuPlacement_CenteredBelowAnchor);
+
+        // A bounced message was never stored, so there is nothing for a reaction to attach to and the
+        // request would fail. The options menu stays: that is where resending and discarding live.
+        if (Message.IsBounced())
+        {
+            ReactionMenuAnchor->SetVisibility(ESlateVisibility::Collapsed);
+        }
     }
 }
 

--- a/Plugins/StreamChat/Source/StreamChatUi/Private/Message/MessageWidget.cpp
+++ b/Plugins/StreamChat/Source/StreamChatUi/Private/Message/MessageWidget.cpp
@@ -174,6 +174,7 @@ void UMessageWidget::NativeConstruct()
     // Not in OnSetup: these need the channel context, and that means walking up to an ancestor.
     // Setup() runs before the list view parents this widget, so there is no ancestor to find yet.
     CreateThreadFooter();
+    CreateModerationWarning();
     CreateActionsMenuAnchor();
 }
 
@@ -286,12 +287,16 @@ UUserWidget* UMessageWidget::CreateActionsMenu()
     UContextMenuWidget* Actions = CreateWidget<UContextMenuWidget>(this, ActionsClass);
 
     // A menu anchor shows exactly one widget, so the picker rides along at the top of the action
-    // sheet rather than as a second menu. That is also where a phone user expects it.
-    if (const TSubclassOf<UReactionPickerWidget> PickerClass = MenuDefaults->GetReactionPickerWidgetClass())
+    // sheet rather than as a second menu. That is also where a phone user expects it. Left out for a
+    // bounced message: it was never stored, so there is nothing for a reaction to attach to.
+    if (!Message.IsBounced())
     {
-        UReactionPickerWidget* Picker = CreateWidget<UReactionPickerWidget>(this, PickerClass);
-        Picker->Setup(Message);
-        Actions->SetHeaderContent(Picker);
+        if (const TSubclassOf<UReactionPickerWidget> PickerClass = MenuDefaults->GetReactionPickerWidgetClass())
+        {
+            UReactionPickerWidget* Picker = CreateWidget<UReactionPickerWidget>(this, PickerClass);
+            Picker->Setup(Message);
+            Actions->SetHeaderContent(Picker);
+        }
     }
 
     Actions->Setup(Message, Side);
@@ -456,5 +461,49 @@ void UMessageWidget::OnThreadFooterClicked()
     if (UChannelContextWidget* Context = UChannelContextWidget::TryGet(this))
     {
         Context->OpenThread(Message);
+    }
+}
+
+bool UMessageWidget::ShouldDisplayModerationWarning() const
+{
+    // IsModerationError already restricts this to the current user's own messages, which is the only
+    // place a bounce can show up: nobody else is ever sent one.
+    return Message.IsModerationError();
+}
+
+void UMessageWidget::CreateModerationWarning()
+{
+    if (!AlignPanel || !WidgetTree)
+    {
+        return;
+    }
+
+    if (ModerationWarningText)
+    {
+        AlignPanel->RemoveChild(ModerationWarningText);
+        ModerationWarningText = nullptr;
+    }
+
+    if (!ShouldDisplayModerationWarning())
+    {
+        return;
+    }
+
+    ModerationWarningText = WidgetTree->ConstructWidget<UTextBlock>();
+    ModerationWarningText->SetText(BouncedMessageText);
+    FSlateFontInfo Font = ModerationWarningText->GetFont();
+    Font.Size = ModerationWarningFontSize;
+    ModerationWarningText->SetFont(Font);
+    if (const UThemeDataAsset* Theme = GetTheme())
+    {
+        ModerationWarningText->SetColorAndOpacity(Theme->GetPaletteColor(Theme->ModerationWarningTextColor));
+    }
+
+    // Last in the panel, so it sits below the bubble. OnSetup's alignment pass has already been and
+    // gone by now, so this slot is aligned to the message's side here instead.
+    if (UVerticalBoxSlot* BoxSlot = Cast<UVerticalBoxSlot>(AlignPanel->AddChild(ModerationWarningText)))
+    {
+        BoxSlot->SetPadding(ModerationWarningPadding);
+        BoxSlot->SetHorizontalAlignment(Side == EMessageSide::Me ? HAlign_Right : HAlign_Left);
     }
 }

--- a/Plugins/StreamChat/Source/StreamChatUi/Public/ContextMenu/ContextMenuWidget.h
+++ b/Plugins/StreamChat/Source/StreamChatUi/Public/ContextMenu/ContextMenuWidget.h
@@ -54,6 +54,16 @@ private:
     virtual void NativePreConstruct() override;
     void AddButton(UContextMenuAction* Action, EContextMenuButtonPosition Position);
 
+    /**
+     * Put an action at the top of the list unless one of its class is configured already.
+     *
+     * For actions newer than WBP_ContextMenu, whose list cannot be extended without editing the
+     * asset. The action itself decides whether it is displayed, so adding it is not the same as
+     * showing it.
+     */
+    template <class TAction>
+    void AddMissingAction();
+
     /// Sits above the buttons once the menu is built. Null unless a caller supplied one.
     UPROPERTY(Transient)
     UWidget* HeaderContent;

--- a/Plugins/StreamChat/Source/StreamChatUi/Public/ContextMenu/ResendMessageContextMenuAction.h
+++ b/Plugins/StreamChat/Source/StreamChatUi/Public/ContextMenu/ResendMessageContextMenuAction.h
@@ -1,0 +1,30 @@
+// Copyright 2026 Stream.IO, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "ContextMenu/ContextMenuAction.h"
+#include "CoreMinimal.h"
+
+#include "ResendMessageContextMenuAction.generated.h"
+
+/**
+ * @brief Message action which sends a moderation-bounced message again, unchanged
+ *
+ * Added to the action list in C++ rather than configured in WBP_ContextMenu, which predates
+ * moderation bounces.
+ *
+ * Only offered on the author's own bounced message. Sending the same text again will usually be
+ * bounced again, so this sits alongside Edit rather than replacing it.
+ */
+UCLASS()
+class STREAMCHATUI_API UResendMessageContextMenuAction final : public UContextMenuAction
+{
+    GENERATED_BODY()
+
+public:
+    UResendMessageContextMenuAction();
+
+protected:
+    virtual void OnPerform(const FMessage&, UWidget* OwningWidget) override;
+    virtual bool OnShouldDisplay(EMessageSide, const FMessage&) const override;
+};

--- a/Plugins/StreamChat/Source/StreamChatUi/Public/Message/MessageWidget.h
+++ b/Plugins/StreamChat/Source/StreamChatUi/Public/Message/MessageWidget.h
@@ -99,6 +99,17 @@ protected:
     UPROPERTY(EditDefaultsOnly, Category = "Message Actions")
     float LongPressMoveTolerance = 4.f;
 
+    /// Space around the warning shown below a message moderation bounced
+    UPROPERTY(EditDefaultsOnly, Category = Moderation)
+    FMargin ModerationWarningPadding = FMargin{2.f, 2.f, 2.f, 0.f};
+
+    UPROPERTY(EditDefaultsOnly, Category = Moderation)
+    int32 ModerationWarningFontSize = 12;
+
+    /// Shown under the author's own message when moderation bounced it back to be rephrased
+    UPROPERTY(EditDefaultsOnly, Category = Moderation)
+    FText BouncedMessageText = NSLOCTEXT("StreamChat", "BouncedMessage", "Not sent. Hold to edit, send anyway or delete.");
+
     /// Shown under a message that has exactly one reply
     UPROPERTY(EditDefaultsOnly, Category = Thread)
     FText OneReplyText = NSLOCTEXT("StreamChat", "OneReply", "1 reply");
@@ -152,6 +163,16 @@ private:
     bool ShouldDisplayThreadFooter() const;
     FText GetThreadFooterText() const;
 
+    /**
+     * Build the "not sent" warning under a message moderation bounced.
+     *
+     * The author is the only one who ever sees a bounced message, and without this the message looks
+     * sent. The actions to do something about it are on the long press menu, which the warning says
+     * so, because a bounced message has no affordance of its own.
+     */
+    void CreateModerationWarning();
+    bool ShouldDisplayModerationWarning() const;
+
     UFUNCTION()
     void OnThreadFooterClicked();
 
@@ -173,6 +194,10 @@ private:
 
     UPROPERTY(Transient)
     UTextBlock* ThreadFooterText;
+
+    /// Also in AlignPanel, below the bubble. Null unless moderation bounced this message.
+    UPROPERTY(Transient)
+    UTextBlock* ModerationWarningText;
 
     /// Hosts the long press menu. Empty and invisible until opened, and spawned in C++ because
     /// WBP_Message has no anchor of its own.

--- a/Plugins/StreamChat/Source/StreamChatUi/Public/ThemeDataAsset.h
+++ b/Plugins/StreamChat/Source/StreamChatUi/Public/ThemeDataAsset.h
@@ -70,6 +70,10 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Thread")
     FName ThreadFooterTextColor = TEXT("accent-primary");
 
+    /// Colour of the warning shown under a message moderation would not let through
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Moderation")
+    FName ModerationWarningTextColor = TEXT("accent-error");
+
     /// The color of the background of the message composer
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Colors|Message Composer")
     FName MessageComposerBackgroundColor = TEXT("bars-bg");

--- a/Source/DocsSamples/Private/Moderation/ModerationTools.cpp
+++ b/Source/DocsSamples/Private/Moderation/ModerationTools.cpp
@@ -3,7 +3,9 @@
 #include "Channel/ChatChannel.h"
 #include "CoreMinimal.h"
 #include "Moderation/Ban.h"
+#include "Moderation/UserBlock.h"
 #include "StreamChatClientComponent.h"
+#include "User/UserManager.h"
 
 namespace ModerationTools
 {
@@ -16,6 +18,75 @@ FUserRef User;
 void Flag()
 {
     Client->FlagMessage(Message);
+
+    // Give the moderators a reason, and any extra context your app has
+    Client->FlagMessage(Message, TEXT("spam"), {{TEXT("origin"), TEXT("in-game report dialog")}});
+
+    Client->FlagUser(User, TEXT("impersonation"));
+
+    // Withdraw a flag raised by mistake
+    Client->UnflagMessage(Message);
+    Client->UnflagUser(User);
+}
+
+// https://getstream.io/chat/docs/unreal/moderation/?language=unreal#block
+void Block()
+{
+    // Hides every 1-on-1 channel shared with that user, and stops their events and push notifications
+    Client->BlockUser(User);
+
+    Client->UnblockUser(User);
+
+    // Nothing else populates FOwnUser::BlockedUserIds, so call this once after connecting if you want
+    // to know whether a user is blocked without asking the API again
+    Client->GetBlockedUsers(
+        [](const TArray<FUserBlock>& Blocks)
+        {
+            for (const FUserBlock& Block : Blocks)
+            {
+                UE_LOG(LogTemp, Log, TEXT("Blocked %s at %s"), *Block.BlockedUser->Id, *Block.CreatedAt.ToString());
+            }
+        });
+
+    const bool bBlocked = UUserManager::Get()->GetCurrentUser().HasBlockedUser(User);
+    UE_LOG(LogTemp, Log, TEXT("Blocked: %d"), bBlocked);
+}
+
+// https://getstream.io/moderation/docs/guides/bounce-message/
+void BouncedMessages()
+{
+    // Moderation can bounce a message back to its author instead of publishing it. The bounced message
+    // is only ever delivered to the author, and is not stored, so it lives in this client's message
+    // list alone. FMessage::Moderation carries the verdict.
+    if (Message.IsBounced())
+    {
+        UE_LOG(LogTemp, Log, TEXT("Bounced, original text was: %s"), *Message.Moderation.OriginalText);
+
+        // Let the author rephrase it. Editing a bounced message sends it afresh rather than updating
+        // one on the server, because there is nothing there to update.
+        FMessage Rephrased = Message;
+        Rephrased.Text = TEXT("Something more polite");
+        Channel->ResendMessage(Rephrased);
+
+        // Or discard it. Deleting a bounced message only removes it locally.
+        Channel->DeleteMessage(Message);
+    }
+
+    // The other verdicts. Remove means the message was taken out of the channel, and Flag means it was
+    // published but sent to the dashboard for a moderator to look at.
+    switch (Message.Moderation.Action)
+    {
+        case EMessageModerationAction::Bounce:
+        case EMessageModerationAction::Remove:
+        case EMessageModerationAction::Flag:
+            break;
+        case EMessageModerationAction::Other:
+            // An action added to the API since this version of the SDK
+            UE_LOG(LogTemp, Log, TEXT("Unrecognised moderation action: %s"), *Message.Moderation.RawAction);
+            break;
+        case EMessageModerationAction::None:
+            break;
+    }
 }
 
 // https://getstream.io/chat/docs/unreal/moderation/?language=unreal#mutes


### PR DESCRIPTION
Brings the Unreal SDK's moderation surface up to what iOS and Android already expose.

## What was missing

The SDK had bans, shadow bans, mutes, blocks, slow mode and a bare `FlagMessage`. Against iOS/Android it was missing Moderation V2 entirely, the whole bounced-message flow, flag reasons, unflagging, and the richer blocked-user model.

## Changes

**Moderation verdicts.** `FMessage::Moderation` carries the action, original text and harm labels, decoded from the V2 `moderation` field and falling back to the older `moderation_details` — V1's action names are normalised to the same enum (`MESSAGE_RESPONSE_ACTION_BLOCK` → `Remove`, matching iOS). The action is kept as a **string** on the DTO rather than a `UENUM`: the deserialiser logs an error and bails on an unknown enum value, so an action added to the API after this build would be dropped. Instead it surfaces as `Other` with `RawAction` intact.

**Bounced messages.** This was a real bug, not just a missing feature. A bounce arrives as HTTP 200 with `type: error` and **no websocket event follows**, so the optimistically-added local message sat at `Sending` for ever. It is now stored as `Failed`, reported as an unsuccessful send (the request succeeded; the send did not), deleted locally-only, and can be sent again. Editing one routes through `ResendMessage` — moderation never stored it, so there is nothing on the server to update and `UpdateMessage` would 404.

**Flagging.** `reason` + custom data on message and user flags, plus `UnflagMessage`/`UnflagUser`.

**Blocked users.** `GetBlockedUsers` yields `FUserBlock { BlockedUser, BlockedBy, CreatedAt }`, and `FOwnUser::BlockedUserIds` / `HasBlockedUser` is maintained from the block endpoints — the only place the API reports a block. It is carried across `SetCurrentUser` by hand, because that re-runs on every mute change and the own-user payload contains no blocks.

**UI, without touching assets.** A bounced message gets a themed warning under the bubble and a *Send anyway* action, both added from C++ the way the existing thread-reply action already is, since `WBP_ContextMenu` predates them and its list cannot be extended without editing the asset. Reactions and thread replies hide themselves on a bounced message.

## Breaking change

`GetBlockedUsers` now takes `TFunction<void(const TArray<FUserBlock>&)>` instead of `TArray<FString>`. Not kept as an overload: two overloads differing only in callback type make lambda call sites ambiguous.

`FlagMessage`/`FlagUser` keep their names on both the C++ and Blueprint sides. The optional forms are overloads rather than default arguments, because UHT cannot parse a default value for a `TMap` parameter in any spelling (`= {}` → *C++ Default parameter not parsed*; `= TMap<FString, FString>()` → *Found '>' when expecting ',' or ')'*).

## Testing

- **73/73 automation tests pass on UE 5.7 and UE 5.8**, including 12 new moderation-parsing tests and live flag-with-reason / unflag API coverage.
- **Packaged with a full cook and run on an iPhone 12 Pro.** `FMessage`, `UMessageWidget` and `UThemeDataAsset` each gained a `UPROPERTY`, and cooked builds use unversioned serialization — properties matched by schema position, not name — so a stale cooked `WBP_` CDO aborts on map load. The editor and the test suite cannot see this. Map loaded, WebSocket connected, `POST /channels` → 201, no SIGABRT.
- **The bounce flow itself is not verified end to end.** The sample's Stream app reports `automod: disabled` with no blocklist, and two deliberately violating probe messages came back `type: regular` with `moderation` absent — there is no policy to bounce against. Wants a run against an app with bouncing configured before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)